### PR TITLE
Repo cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ out
 gen
 
 doc/
+
+*.autosave

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,265 +1,107 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(phoxi_camera)
 
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS
-  dynamic_reconfigure
-  pcl_ros
-  roscpp
-  roslib
-  rospy
-  sensor_msgs
-  pcl_conversions
-  std_msgs
-  tf
+find_package(PhoXi REQUIRED CONFIG PATHS "$ENV{PHOXI_CONTROL_PATH}")
+
+find_package(catkin REQUIRED
+  COMPONENTS
+    roscpp
+    roslib
+    rospy
+    std_msgs
+    sensor_msgs
+    pcl_ros
+    pcl_conversions
+    dynamic_reconfigure
+    tf
 )
 
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
+include_directories(include
+  ${catkin_INCLUDE_DIRS}
+  ${PHOXI_INCLUDE_DIRS}
+)
 
+add_message_files(
+  FILES
+    PhoXiSize.msg
+)
 
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-# catkin_python_setup()
+add_service_files(
+  FILES
+    GetDeviceList.srv
+    ConnectCamera.srv
+    IsAcquiring.srv
+    GetFrame.srv
+    TriggerImage.srv
+    GetHardwareIdentification.srv
+    GetSupportedCapturingModes.srv
+    IsConnected.srv
+)
 
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend tag for "message_generation"
-##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
-##     but can be declared for certainty nonetheless:
-##     * add a run_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
- add_message_files(
-   FILES
-   PhoXiSize.msg
- )
-
-## Generate services in the 'srv' folder
- add_service_files(
-   FILES
-         GetDeviceList.srv
-         ConnectCamera.srv
-         IsAcquiring.srv
-         GetFrame.srv
-         TriggerImage.srv
-         GetHardwareIdentification.srv
-         GetSupportedCapturingModes.srv
-         IsConnected.srv
- )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
- generate_messages(
-   DEPENDENCIES
-   sensor_msgs std_msgs
- )
-
-################################################
-## Declare ROS dynamic reconfigure parameters ##
-################################################
-
-## To declare and build dynamic reconfigure parameters within this
-## package, follow these steps:
-## * In the file package.xml:
-##   * add a build_depend and a run_depend tag for "dynamic_reconfigure"
-## * In this file (CMakeLists.txt):
-##   * add "dynamic_reconfigure" to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * uncomment the "generate_dynamic_reconfigure_options" section below
-##     and list every .cfg file to be processed
-
-## Generate dynamic reconfigure parameters in the 'cfg' folder
-# generate_dynamic_reconfigure_options(
-#   cfg/DynReconf1.cfg
-#   cfg/DynReconf2.cfg
-# )
+generate_messages(
+  DEPENDENCIES
+    std_msgs
+    sensor_msgs
+)
 
 generate_dynamic_reconfigure_options(
-        cfg/phoxi_camera.cfg
+  cfg/phoxi_camera.cfg
 )
-
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if you package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
 
 catkin_package(
-        CATKIN_DEPENDS message_runtime std_msgs sensor_msgs
-        #  INCLUDE_DIRS include
-#  LIBRARIES pho_driver
-#  CATKIN_DEPENDS dynamic_reconfigure pcl_ros roscpp roslib rospy sensor_msgs std_msgs tf
-#  DEPENDS system_lib
+  CATKIN_DEPENDS
+    roscpp
+    message_runtime
+    std_msgs
+    sensor_msgs 
 )
-
-###########
-## Build ##
-###########
-
 
 add_compile_options(-w)
 add_compile_options(-std=c++11)
 add_compile_options(-fpermissive)
 add_compile_options(-pthread)
 
-## Specify additional locations of header files
-## Your package locations should be listed before other locations
-# include_directories(include)
-#set(BOOST_ROOT /home/msladek/3rdParty_REPO/boost_1_60_0)
-find_package(PhoXi REQUIRED CONFIG PATHS "$ENV{PHOXI_CONTROL_PATH}")
-
-
-#FIND_PACKAGE(Boost REQUIRED COMPONENTS
-#        system
-#        filesystem
-#        thread
-#        date_time
-#        iostreams
-#        serialization
-#        chrono
-#        atomic
-#        regex
-#        log
-#        )
-
-include_directories(
-  ${catkin_INCLUDE_DIRS}
-  ${PHOXI_INCLUDE_DIRS}
+add_executable(
+  ${PROJECT_NAME}
+  src/phoxi_camera_node.cpp
 )
 
-## Declare a C++ library
-# add_library(phoxi_driver
-#         src/phoxi_camera_node.cpp
-# )
+add_dependencies(
+  ${PROJECT_NAME}
+  ${PROJECT_NAME}_gencfgv
+  ${${PROJECT_NAME}_EXPORTED_TARGETS}
+  ${catkin_EXPORTED_TARGETS}
+)
 
-## Add cmake target dependencies of the library
-## as an example, code may need to be generated before libraries
-## either from message generation or dynamic reconfigure
-# add_dependencies(pho_driver ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(
+  ${PROJECT_NAME}
+  debug ${catkin_LIBRARIES}
+  optimized ${catkin_LIBRARIES}
+  ${PHOXI_LIBRARY}
+  ${Boost_LIBRARIES}
+  rt
+)
 
-## Declare a C++ executable
-# add_executable(pho_driver_node src/pho_driver_node.cpp)
-
-add_executable(phoxi_camera_node src/phoxi_camera_node.cpp)
-
-## Add cmake target dependencies of the executable
-## same as for the library above
-# add_dependencies(pho_driver_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-add_dependencies(phoxi_camera_node ${PROJECT_NAME}_gencfgv ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Specify libraries to link a library or executable target against
-# target_link_libraries(pho_driver_node
-#   ${catkin_LIBRARIES}
-# )
-
-#message(${PHOXI_LIBRARY})
-target_link_libraries(phoxi_camera_node
-        debug ${catkin_LIBRARIES}
-        optimized ${catkin_LIBRARIES}
-        ${PHOXI_LIBRARY}
-        #debug ${Boost_LIBRARIES}
-        #optimized ${Boost_LIBRARIES}
-        ${Boost_LIBRARIES}
-        rt
-        )
-
-#############
-## Install ##
-#############
-
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
- install(PROGRAMS src/phoxi_camera_example.py
-   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+install(
+  PROGRAMS
+    src/phoxi_camera_example.py
+    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
  )
 
+install(
+  TARGETS
+    ${PROJECT_NAME}
+  ARCHIVE
+    DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY
+    DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME
+    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
-## Mark executables and/or libraries for installation
- install(TARGETS phoxi_camera_node
-   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
- )
-
-#message(${PHOXI_LIB_RELEASE_PER_COMPILER}.${PHO_SOFTWARE_VERSION})
-install(FILES ${PHOXI_LIB_RELEASE_PER_COMPILER}.${PHO_SOFTWARE_VERSION}
-        DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        )
-
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
-
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
-
-#############
-## Testing ##
-#############
-
-## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_pho_driver.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
-
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)
-#add dynamic reconfigure api
-find_package(catkin REQUIRED COMPONENTS
-        roscpp
-        rospy
-        std_msgs
-        message_generation
-        )
-
-
-
-# make sure configure headers are built before any node using them
+install(
+  FILES
+    ${PHOXI_LIB_RELEASE_PER_COMPILER}.${PHO_SOFTWARE_VERSION}
+  DESTINATION
+    ${CATKIN_PACKAGE_LIB_DESTINATION}
+)

--- a/README.md
+++ b/README.md
@@ -1,29 +1,69 @@
 # phoxi_camera
 
-ROS Package for PhoXi Scanner/Camera
+This package enables interfacing Photoneo PhoXi 3D Scanner/Camera from ROS. 
 
-if you don't have catkin workspace:
+<img src="http://www.smartroboticsys.eu/wp-content/uploads/2016/11/photoneo_scanner.png" width="640">
+
+###Install
+*phoxi_camera* package depends on several state-of-the-art libraries and latest version of g++ compiler. Script *install_prerequisities.sh* which is available in main repo folde install all packages and libraries required for successfull phoxi_camera compilation. Follow steps below to get phoxi_camera package working properly on your system: 
+
 ```
-mkdir -p ~/catkin_workspace_directory/src
-cd ~/catkin_workspace_directory/src
-catkin_init_workspace
-```
-then:
-```
-cd ~/catkin_workspace_directory/src
+cd catkin_ws/src
 git clone https://github.com/photoneo/phoxi_camera.git
-cd ..
+cd phoxi_camera
+chmod +x install_prerequisities.sh
+./install_prerequisities.sh
+cd ../..
 catkin_make
-source ~/catkin_workspace_directory/devel/setup.bash
-rosrun phoxi_camera phoxi_camera_node
-rosrun phoxi_camera phoxi_camera_example.py
 ```
-In phoxi_camera_example.py change hardware identification of camera
+###Test PhoXi ROS interface without real 3D scanner
+It is possible to test PhoXi ROS interface without real hardware. 
+- Start PhoXiControl application 
+- Launch simple test example```roslaunch phoxi_camera phoxi_camera_test.launch```
+- Application should connect to the camera and start aquiring example pointclouds
+- Notice that pointcloud data are also being published on ROS topics
+- Use available ROS services to control the dummy camera.
 
-Generate package:
+<img src="http://www.smartroboticsys.eu/wp-content/uploads/2016/11/PhoXiControl_01.jpg" width="640">
+
+####Available ROS services
 ```
-catkin_generate_changelog
-catkin_prepare_release
-# must have git 1.x.x
-bloom-release --rosdistro <ros_distro> --track <ros_distro> phoxi_camera
+/phoxi_camera/connect_camera
+/phoxi_camera/disconnect_camera
+/phoxi_camera/get_device_list
+/phoxi_camera/get_frame
+/phoxi_camera/get_hardware_indentification
+/phoxi_camera/get_loggers
+/phoxi_camera/get_supported_capturing_modes
+/phoxi_camera/is_acquiring
+/phoxi_camera/is_connected
+/phoxi_camera/set_logger_level
+/phoxi_camera/set_parameters
+/phoxi_camera/start_acquisition
+/phoxi_camera/stop_acquisition
+/phoxi_camera/trigger_image
+/phoxi_camera_example/get_loggers
+/phoxi_camera_example/set_logger_level
 ```
+
+####Available ROS topics
+```
+/phoxi_camera/confidence_map
+/phoxi_camera/normal_map
+/phoxi_camera/parameter_descriptions
+/phoxi_camera/parameter_updates
+/phoxi_camera/pointcloud
+/phoxi_camera/texture
+```
+
+
+###Test PhoXi ROS interface with real device
+- Start PhoXiControl application 
+- Connect to your device
+- Run Interface node ```rosrun phoxi_camera phoxi_camera ```
+- Use available ROS services to control your 3D scanner
+
+<img src=http://www.smartroboticsys.eu/wp-content/uploads/2016/11/PhoXiControl_02.jpg width="640">
+
+See phoxi_camera [ROS Wiki page](http://wiki.ros.org/phoxi_camera) for further details. 
+

--- a/install_prerequisities.sh
+++ b/install_prerequisities.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+sudo apt-get -y update \
+    && sudo apt-get -y upgrade \
+    && sudo apt-get install -y vim screen tree ssh
+
+sudo apt -y install software-properties-common \
+	&& sudo add-apt-repository -y ppa:freecad-maintainers/freecad-stable \
+	&& sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+	&& sudo add-apt-repository -y ppa:git-core/ppa \
+	&& sudo apt update \
+	&& sudo apt -y upgrade \
+	&& sudo apt -y install g++ g++-4.9 gcc-4.9 \
+	&& sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9 \
+	&& sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9 \
+	&& sudo apt -y remove git \
+	&& sudo apt -y install git cmake cmake-curses-gui cmake-qt-gui libgtk2.0-dev pkg-config doxygen graphviz chrpath \
+	libavcodec-dev libavformat-dev libswscale-dev libxt-dev python-numpy \
+	libeigen3-dev libflann-dev libusb-1.0-0-dev libqhull-dev libtiff5-dev libavahi-client-dev \
+	libbz2-dev makeself mesa-common-dev python2.7-dev gawk dh-autoreconf \
+	liboce-foundation-dev liboce-modeling-dev liboce-ocaf-dev libxerces-c-dev
+
+sudo add-apt-repository -y ppa:webupd8team/sublime-text-3 \
+	&& sudo apt update \
+	&& sudo apt -y upgrade \
+	&& sudo apt -y install meshlab sublime-text-installer freecad searchmonkey \
+	&& sudo apt -y install libxmlrpc-c++8 libxmlrpc-c++8-dev
+
+wget https://github.com/NixOS/patchelf/archive/0.9.tar.gz
+tar -xzvf 0.9.tar.gz
+cd patchelf-0.9
+./bootstrap.sh
+./configure
+sudo make install

--- a/launch/phoxi_camera_test.launch
+++ b/launch/phoxi_camera_test.launch
@@ -1,4 +1,4 @@
 <launch>
-    <node pkg="phoxi_camera" type="phoxi_camera_node" name="phoxi_camera_node" output="screen"/>
+    <node pkg="phoxi_camera" type="phoxi_camera" name="phoxi_camera" output="screen"/>
     <node pkg="phoxi_camera" type="phoxi_camera_example.py" name="phoxi_camera_example" output="screen"/>
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -2,47 +2,20 @@
 <package>
   <name>phoxi_camera</name>
   <version>1.1.4</version>
-  <description>The phoxi_camera package</description>
+  <description>The phoxi_camera is a package that enables interfacing Photoneo Phoxi Scanner/Camera from ROS</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="filipsladek@gmail.com">Filip Sladek</maintainer>
-  <maintainer email="matejsladek10@gmail.com">Matej Sladek</maintainer>
-  <author email="filipsladek@gmail.com">Filip Sladek</author>
-  <author email="matejsladek10@gmail.com">Matej Sladek</author>
+  <author>Matej Sladek</author>
+  <author>Filip Sladek</author>
 
+  <maintainer email="msladek@photoneo.com">Matej Sladek</maintainer>
 
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
   <license>BSD</license>
 
+  <url>http://wiki.ros.org/phoxi_camera</url>
 
-  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/pho_driver</url> -->
-
-
-  <!-- Author tags are optional, mutiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintianers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
-
-  <!-- The *_depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use build_depend for packages you need at compile time: -->
-     <build_depend>message_generation</build_depend>
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use run_depend for packages you need at runtime: -->
-     <run_depend>message_runtime</run_depend>
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>message_generation</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>pcl_ros</build_depend>
   <build_depend>roscpp</build_depend>
@@ -53,6 +26,8 @@
   <build_depend>std_srvs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>libpcl-all-dev</build_depend>
+
+  <run_depend>message_runtime</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>pcl_ros</run_depend>
   <run_depend>roscpp</run_depend>
@@ -64,9 +39,4 @@
   <run_depend>tf</run_depend>
   <run_depend>libpcl-all</run_depend>
 
-  <!-- The export tag contains other, unspecified, tags -->
-  <export>
-    <!-- Other tools can request additional information be placed here -->
-
-  </export>
 </package>


### PR DESCRIPTION
Preklopene z forkovaneho repa. 

Tentokrat som v **phoxi_camera_node.cpp** nerobil take vyrazne zmeny, pridal som licenciu, poprehadzoval headre do suvisiacich skupin, vyhodil WIN definy a headre ako <vector> <unistd> kedze tie natahuje ros.h. ROS_INFO vypisy som prepisal na std::cout nech je to jednotne aj v kode aj v konzole. Zvysok zostal viac menej bezo zmeny. 

Odporucam este precistit kod od zbytocne zakomentovanych riadkov kodu
Volbu formatingu nechavam na maintainera 

CMakeLists, package.xml upravene podla ROS konvencii,
CMakeLists a novy launch file fixuje "_node" bug 

Pridany **install_prerequisities.sh** kvoli priprave systemu na kompilaciu phoxi_camera 

Updatovana dokumentacia README.md