### PR TITLE
Added publishing of point clouds with color information.

### DIFF
--- a/cfg/phoxi_camera.cfg
+++ b/cfg/phoxi_camera.cfg
@@ -50,6 +50,9 @@ coordination_space_enum = gen.enum([gen.const("CameraSpace", int_t, 1, "CameraSp
 
 gen.add("coordination_space", int_t, 1 << 12, "Coordination space which is edited via an enum", 1, 1, 5, edit_method=coordination_space_enum)
 
+gen.add("min_intensity", double_t, 1 << 13, "Min value for rescaling the range of the intensity texture", 0.0, 0.0, 65535.0)
+gen.add("max_intensity", double_t, 1 << 14, "Max value for rescaling the range of the intensity texture", 0.0, 0.0, 65535.0)
+
 
 
 exit(gen.generate(PACKAGE, "phoxi_camera_node", "phoxi_camera"))

--- a/include/phoxi_camera/PhoXiInterface.h
+++ b/include/phoxi_camera/PhoXiInterface.h
@@ -10,6 +10,8 @@
 #include <pcl_ros/point_cloud.h>
 #include <Eigen/Core>
 #include <phoxi_camera/PhoXiException.h>
+#include <cstdint>
+#include <limits>
 
 //* PhoXiInterface
 /**
@@ -22,7 +24,7 @@ public:
     /**
     * Default constructor.
     */
-    PhoXiCamera();
+    PhoXiInterface();
 
     /**
     * Return all PhoXi 3D Scanners ids connected on netwok.
@@ -59,11 +61,11 @@ public:
     *
     * \throw PhoXiScannerNotConnected when no scanner is connected
     */
-    std::shared_ptr<pcl::PointCloud<pcl::PointNormal>> getPointCloud();
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZRGBNormal>> getPointCloud();
     /**
     * Convert PFrame to point cloud
     */
-    static std::shared_ptr<pcl::PointCloud<pcl::PointNormal>> getPointCloudFromFrame(pho::api::PFrame frame);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZRGBNormal>> getPointCloudFromFrame(pho::api::PFrame frame);
     /**
     * Test if connection to PhoXi 3D Scanner is working
     *
@@ -195,9 +197,35 @@ public:
     * \throw PhoXiScannerNotConnected when no scanner is connected
     */
     pho::api::PhoXiTriggerMode getTriggerMode();
+    /**
+     * Gets the minimum intensity when coloring point cloud from the image texture
+     */
+    float getMinIntensity() const {
+        return minIntensity;
+    }
+    /**
+     * Sets the minimum intensity when coloring point cloud from the image texture
+     */
+    void setMinIntensity(float minIntensity) {
+        PhoXiInterface::minIntensity = minIntensity;
+    }
+    /**
+     * Gets the maximum intensity when coloring point cloud from the image texture
+     */
+    float getMaxIntensity() const {
+        return maxIntensity;
+    }
+    /**
+     * Gets the maximum intensity when coloring point cloud from the image texture
+     */
+    void setMaxIntensity(float maxIntensity) {
+        PhoXiInterface::maxIntensity = maxIntensity;
+    }
 protected:
     pho::api::PPhoXi scanner;
     pho::api::PhoXiFactory phoXiFactory;
+    float minIntensity;
+    float maxIntensity;
 private:
 
 

--- a/launch/phoxi_camera.launch
+++ b/launch/phoxi_camera.launch
@@ -1,5 +1,10 @@
 <launch>
-    <node pkg="phoxi_camera" type="phoxi_camera" name="phoxi_camera" output="screen">
+    <node pkg="phoxi_camera" type="phoxi_camera" name="phoxi_camera" output="screen" clear_params="true">
         <rosparam file="$(find phoxi_camera)/config/phoxi_camera.yaml" command="load"/>
+    </node>
+
+    <node name="$(anon dynparam)" pkg="dynamic_reconfigure" type="dynparam" args="set_from_parameters phoxi_camera">
+        <param name="min_intensity" type="double" value="0.0" />
+        <param name="max_intensity" type="double" value="0.0" />
     </node>
 </launch>

--- a/src/PhoXiInterface.cpp
+++ b/src/PhoXiInterface.cpp
@@ -4,7 +4,7 @@
 
 #include "phoxi_camera/PhoXiInterface.h"
 
-PhoXiInterface::PhoXiCamera(){
+PhoXiInterface::PhoXiInterface() : minIntensity(0.0f), maxIntensity(0.0f) {
 
 }
 
@@ -66,27 +66,62 @@ pho::api::PFrame PhoXiInterface::getPFrame(int id){
     return  scanner->GetSpecificFrame(id,10000);
 }
 
-std::shared_ptr<pcl::PointCloud<pcl::PointNormal>> PhoXiInterface::getPointCloud() {
+std::shared_ptr<pcl::PointCloud<pcl::PointXYZRGBNormal>> PhoXiInterface::getPointCloud() {
     return getPointCloudFromFrame(getPFrame(-1));
 }
 
-static std::shared_ptr<pcl::PointCloud<pcl::PointNormal>> PhoXiInterface::getPointCloudFromFrame(pho::api::PFrame frame) {
+std::shared_ptr<pcl::PointCloud<pcl::PointXYZRGBNormal>> PhoXiInterface::getPointCloudFromFrame(pho::api::PFrame frame) {
     if (!frame || !frame->Successful) {
         throw CorruptedFrame("Corrupted frame!");
     }
-    std::shared_ptr <pcl::PointCloud<pcl::PointNormal>>cloud(new pcl::PointCloud<pcl::PointNormal>(frame->GetResolution().Width,frame->GetResolution().Height));
+    bool autoMinMaxIntensityUsed = false;
+    bool textureAvailable = scanner->OutputSettings->SendTexture && !frame->Texture.Empty();
+    if (textureAvailable) {
+        if (minIntensity < 0.0f || maxIntensity <= 0.0f || minIntensity >= maxIntensity) {
+            minIntensity = std::numeric_limits<float>::max();
+            maxIntensity = std::numeric_limits<float>::min();
+            autoMinMaxIntensityUsed = true;
+            for(int r = 0; r < frame->Texture.Size.Height; r++) {
+                for (int c = 0; c < frame->Texture.Size.Width; c++) {
+                    auto point = frame->PointCloud.At(r,c);
+                    if (point.x > 0 && point.y > 0 && point.z > 0) {
+                        float intensity = frame->Texture.At(r,c);
+                        if (intensity > maxIntensity)
+                            maxIntensity = intensity;
+                        if (intensity < minIntensity)
+                            minIntensity = intensity;
+                    }
+                }
+            }
+        }
+    }
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZRGBNormal>> cloud(new pcl::PointCloud<pcl::PointXYZRGBNormal>(frame->GetResolution().Width,frame->GetResolution().Height));
     for(int r = 0; r < frame->GetResolution().Height; r++){
         for (int c = 0; c < frame->GetResolution().Width; c++){
-            //todo
             auto point = frame->PointCloud.At(r,c);
             auto normal = frame->NormalMap.At(r,c);
-            Eigen::Vector3f eigenPoint(point.x, point.y, point.z);
-            Eigen::Vector3f eigenNormal(point.x, point.y, point.z);
-            pcl::PointNormal pclPoint;
-            pclPoint.getVector3fMap() = eigenPoint/1000;  //to [m]
-            pclPoint.getNormalVector3fMap() = eigenNormal/1000; //to [m]
+            uint8_t intensity8Bits = 0;
+            if (textureAvailable) {
+                float intensityMaxTruncated = std::min((float)frame->Texture.At(r,c), maxIntensity);
+                float intensityMinTruncated = std::max(intensityMaxTruncated, minIntensity);
+                intensity8Bits = (uint8_t)((intensityMinTruncated - minIntensity) / (maxIntensity - minIntensity) * std::numeric_limits<uint8_t>::max());
+            }
+            pcl::PointXYZRGBNormal pclPoint;
+            pclPoint.x = point.x / 1000.0;
+            pclPoint.y = point.y / 1000.0;
+            pclPoint.z = point.z / 1000.0;
+            pclPoint.normal_x = normal.x;
+            pclPoint.normal_y = normal.y;
+            pclPoint.normal_z = normal.z;
+            pclPoint.r = intensity8Bits;
+            pclPoint.g = intensity8Bits;
+            pclPoint.b = intensity8Bits;
             cloud->at(c,r) = pclPoint;
         }
+    }
+    if (autoMinMaxIntensityUsed) {
+        minIntensity = 0.0f;
+        maxIntensity = 0.0f;
     }
     return cloud;
 }


### PR DESCRIPTION
Added publishing of point clouds with color information retrieved from the intensity texture with support for automatically computing the min and max intensity for equalizing the range (or using a specified range in the dynamic reconfigure configuration).