### PR TITLE
Colored pointclouds with manual or automatic normalization and also histogram equalization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,11 @@ generate_dynamic_reconfigure_options(
 )
 
 catkin_package(
+  INCLUDE_DIRS
+    include
+  LIBRARIES
+    ${PROJECT_NAME}_PhoXi_Interface
+    ${PROJECT_NAME}_Ros_Interface
   CATKIN_DEPENDS
     roscpp
     message_runtime

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,9 +38,9 @@ add_message_files(
 
 add_service_files(
   FILES
-    Deprecated/Empty.srv        #depricated
-    Deprecated/IsConnected.srv  #depricated
-    Deprecated/IsAcquiring.srv  #depricated
+    Deprecated/Empty.srv        #deprecated
+    Deprecated/IsConnected.srv  #deprecated
+    Deprecated/IsAcquiring.srv  #deprecated
     ConnectCamera.srv
     TriggerImage.srv
     GetDeviceList.srv
@@ -95,15 +95,15 @@ add_executable(
 
 add_dependencies(
   ${PROJECT_NAME}_Ros_Interface
-  ${PROJECT_NAME}/_PhoXi_Interfece
-  ${PROJECT_NAME}_gencfgv
+  ${PROJECT_NAME}_PhoXi_Interface
+  ${PROJECT_NAME}_gencfg
   ${${PROJECT_NAME}_EXPORTED_TARGETS}
   ${catkin_EXPORTED_TARGETS}
 )
 
 add_dependencies(
   ${PROJECT_NAME}
-  ${PROJECT_NAME}_gencfgv
+  ${PROJECT_NAME}_gencfg
   ${${PROJECT_NAME}_EXPORTED_TARGETS}
   ${catkin_EXPORTED_TARGETS}
 )

--- a/cfg/phoxi_camera.cfg
+++ b/cfg/phoxi_camera.cfg
@@ -50,6 +50,9 @@ coordination_space_enum = gen.enum([gen.const("CameraSpace", int_t, 1, "CameraSp
 
 gen.add("coordination_space", int_t, 1 << 12, "Coordination space which is edited via an enum", 1, 1, 5, edit_method=coordination_space_enum)
 
+gen.add("min_intensity", double_t, 1 << 13, "Min value for rescaling the range of the intensity texture", 0.0, 0.0, 65535.0)
+gen.add("max_intensity", double_t, 1 << 14, "Max value for rescaling the range of the intensity texture", 0.0, 0.0, 65535.0)
+
 
 
 exit(gen.generate(PACKAGE, "phoxi_camera_node", "phoxi_camera"))

--- a/cfg/phoxi_camera.cfg
+++ b/cfg/phoxi_camera.cfg
@@ -52,7 +52,7 @@ gen.add("coordination_space", int_t, 1 << 12, "Coordination space which is edite
 
 gen.add("min_intensity", double_t, 1 << 13, "Min value for rescaling the range of the intensity texture", 0.0, 0.0, 65535.0)
 gen.add("max_intensity", double_t, 1 << 14, "Max value for rescaling the range of the intensity texture", 0.0, 0.0, 65535.0)
-
+gen.add("generate_point_cloud_with_only_valid_points", bool_t, 1 << 15, "Send only valid points in a sparse point cloud (if true).", False)
 
 
 exit(gen.generate(PACKAGE, "phoxi_camera_node", "phoxi_camera"))

--- a/cfg/phoxi_camera.cfg
+++ b/cfg/phoxi_camera.cfg
@@ -50,9 +50,12 @@ coordination_space_enum = gen.enum([gen.const("CameraSpace", int_t, 1, "CameraSp
 
 gen.add("coordination_space", int_t, 1 << 12, "Coordination space which is edited via an enum", 1, 1, 5, edit_method=coordination_space_enum)
 
-gen.add("min_intensity", double_t, 1 << 13, "Min value for rescaling the range of the intensity texture", 0.0, 0.0, 65535.0)
-gen.add("max_intensity", double_t, 1 << 14, "Max value for rescaling the range of the intensity texture", 0.0, 0.0, 65535.0)
-gen.add("generate_point_cloud_with_only_valid_points", bool_t, 1 << 15, "Send only valid points in a sparse point cloud (if true).", False)
+gen.add("texture_min_intensity", double_t, 1 << 13, "Manual min value for rescaling the range of the intensity texture", 0.0, 0.0, 65535.0)
+gen.add("texture_max_intensity", double_t, 1 << 14, "Manual max value for rescaling the range of the intensity texture", 0.0, 0.0, 65535.0) # Auto MinMax will be used if max_intensity <= 0 or min > max
+gen.add("texture_contrast_limited_adaptive_histogram_equalization_clip_limit", double_t, 1 << 15, "Clip limit for contrast Limited Adaptive Histogram Equalization", 4.0, 0.0, 1000.0)
+gen.add("texture_contrast_limited_adaptive_histogram_equalization_size_x", int_t, 1 << 16, "Number of divisions in the X axis for the Contrast Limited Adaptive Histogram Equalization", 4, 0, 100) # CLAHE will not be used if size_x == 0
+gen.add("texture_contrast_limited_adaptive_histogram_equalization_size_y", int_t, 1 << 17, "Number of divisions in the Y axis for the Contrast Limited Adaptive Histogram Equalization", 4, 0, 100) # CLAHE will not be used if size_y == 0
+gen.add("generate_point_cloud_with_only_valid_points", bool_t, 1 << 18, "Send only valid points in a sparse point cloud (if true).", False)
 
 
 exit(gen.generate(PACKAGE, "phoxi_camera_node", "phoxi_camera"))

--- a/config/phoxi_camera.yaml
+++ b/config/phoxi_camera.yaml
@@ -1,4 +1,4 @@
-scanner_id: "InstalledExamples-PhoXi-example"
+scanner_id: "InstalledExamples-basic-example"
 frame_id: "PhoXi3Dscanner_sensor"
 latch_topics: true
 topic_queue_size: 1

--- a/config/phoxi_camera.yaml
+++ b/config/phoxi_camera.yaml
@@ -1,8 +1,8 @@
 scanner_id: "InstalledExamples-PhoXi-example"
 frame_id: "PhoXi3Dscanner_sensor"
-latch_tipics: true
+latch_topics: true
 topic_queue_size: 1
-init_from_config: false # if true all following parameters will be inicialized from this config otherwise from PohXi control application.
+init_from_config: false # if true all following parameters will be inicialized from this config otherwise from PhoXi control application.
 # All following parameters are for PhoXi Control and they can override all dynamic_reconfigure parameters in cfg file.
 # This values are set to scanner after successful connection only if init_from_config parameter is true.
 coordination_space: 1 # 1 = Camera, 2 =  Mounting, 3 = Marker, 4 = Robot, 5 = Custom

--- a/include/phoxi_camera/PhoXiInterface.h
+++ b/include/phoxi_camera/PhoXiInterface.h
@@ -10,6 +10,8 @@
 #include <pcl_ros/point_cloud.h>
 #include <Eigen/Core>
 #include <phoxi_camera/PhoXiException.h>
+#include <cstdint>
+#include <limits>
 
 //* PhoXiInterface
 /**
@@ -22,7 +24,7 @@ public:
     /**
     * Default constructor.
     */
-    PhoXiCamera();
+    PhoXiInterface();
 
     /**
     * Return all PhoXi 3D Scanners ids connected on netwok.
@@ -59,11 +61,11 @@ public:
     *
     * \throw PhoXiScannerNotConnected when no scanner is connected
     */
-    std::shared_ptr<pcl::PointCloud<pcl::PointNormal>> getPointCloud();
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZRGBNormal>> getPointCloud();
     /**
     * Convert PFrame to point cloud
     */
-    static std::shared_ptr<pcl::PointCloud<pcl::PointNormal>> getPointCloudFromFrame(pho::api::PFrame frame);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZRGBNormal>> getPointCloudFromFrame(pho::api::PFrame frame);
     /**
     * Test if connection to PhoXi 3D Scanner is working
     *
@@ -195,9 +197,35 @@ public:
     * \throw PhoXiScannerNotConnected when no scanner is connected
     */
     pho::api::PhoXiTriggerMode getTriggerMode();
+    /**
+     * Gets the minimum intensity when coloring point cloud from the image texture
+     */
+    float getMinIntensity() const {
+        return minIntensity;
+    }
+    /**
+     * Sets the minimum intensity when coloring point cloud from the image texture
+     */
+    void setMinIntensity(float minIntensity) {
+        PhoXiInterface::minIntensity = minIntensity;
+    }
+    /**
+     * Gets the maximum intensity when coloring point cloud from the image texture
+     */
+    float getMaxIntensity() const {
+        return maxIntensity;
+    }
+    /**
+     * Gets the maximum intensity when coloring point cloud from the image texture
+     */
+    void setMaxIntensity(float maxIntensity) {
+        PhoXiInterface::maxIntensity = maxIntensity;
+    }
 protected:
     pho::api::PPhoXi scanner;
     pho::api::PhoXiFactory phoXiFactory;
+    float minIntensity;
+    float maxIntensity;
 private:
 
 

--- a/include/phoxi_camera/PhoXiInterface.h
+++ b/include/phoxi_camera/PhoXiInterface.h
@@ -221,11 +221,31 @@ public:
     void setMaxIntensity(float maxIntensity) {
         PhoXiInterface::maxIntensity = maxIntensity;
     }
+    /**
+     * Gets the flag for specifying that only valid points should be used when
+     * generating a point cloud.
+     */
+    bool getGeneratePointCloudWithOnlyValidPoints() const {
+        return generatePointCloudWithOnlyValidPoints;
+    }
+    /**
+     * Sets the flag for specifying that only valid points should be used when
+     * generating a point cloud. As a result, the point cloud will be sparse and
+     * no longer retain its underlying 2D structure
+     */
+    void setGeneratePointCloudWithOnlyValidPoints(bool generatePointcloudWithOnlyValidPoints) {
+        PhoXiInterface::generatePointCloudWithOnlyValidPoints = generatePointcloudWithOnlyValidPoints;
+    }
+    /**
+     * Value associated with an invalid point for which the depth value could not be calculated
+     */
+    static const pho::api::Point3_32f invalidPoint;
 protected:
     pho::api::PPhoXi scanner;
     pho::api::PhoXiFactory phoXiFactory;
     float minIntensity;
     float maxIntensity;
+    bool generatePointCloudWithOnlyValidPoints;
 private:
 
 

--- a/include/phoxi_camera/PhoXiInterface.h
+++ b/include/phoxi_camera/PhoXiInterface.h
@@ -12,6 +12,17 @@
 #include <phoxi_camera/PhoXiException.h>
 #include <cstdint>
 #include <limits>
+#include <opencv2/core.hpp>
+
+/**
+ * PFrame with post-processed data
+ */
+class FramePostProcessed {
+    public:
+        pho::api::PFrame PFrame;
+        cv::Mat TextureAfterPostProcessing;
+};
+typedef std::shared_ptr <FramePostProcessed> PFramePostProcessed;
 
 //* PhoXiInterface
 /**
@@ -55,7 +66,11 @@ public:
     * \param id - frame id to return
     * \throw PhoXiScannerNotConnected when no scanner is connected
     */
-    pho::api::PFrame getPFrame(int id = -1);
+    PFramePostProcessed getPFrame(int id = -1);
+    /**
+     * Post processing stage of frame data
+     */
+    PFramePostProcessed postProcessFrame(pho::api::PFrame frame);
     /**
     * Get point cloud
     *
@@ -65,7 +80,7 @@ public:
     /**
     * Convert PFrame to point cloud
     */
-    std::shared_ptr<pcl::PointCloud<pcl::PointXYZRGBNormal>> getPointCloudFromFrame(pho::api::PFrame frame);
+    std::shared_ptr<pcl::PointCloud<pcl::PointXYZRGBNormal>> getPointCloudFromFrame(PFramePostProcessed frame);
     /**
     * Test if connection to PhoXi 3D Scanner is working
     *
@@ -200,26 +215,62 @@ public:
     /**
      * Gets the minimum intensity when coloring point cloud from the image texture
      */
-    float getMinIntensity() const {
-        return minIntensity;
+    float getTextureMinIntensity() const {
+        return textureMinIntensity;
     }
     /**
      * Sets the minimum intensity when coloring point cloud from the image texture
      */
-    void setMinIntensity(float minIntensity) {
-        PhoXiInterface::minIntensity = minIntensity;
+    void setTextureMinIntensity(float minIntensity) {
+        PhoXiInterface::textureMinIntensity = minIntensity;
     }
     /**
      * Gets the maximum intensity when coloring point cloud from the image texture
      */
-    float getMaxIntensity() const {
-        return maxIntensity;
+    float getTextureMaxIntensity() const {
+        return textureMaxIntensity;
     }
     /**
      * Gets the maximum intensity when coloring point cloud from the image texture
      */
-    void setMaxIntensity(float maxIntensity) {
-        PhoXiInterface::maxIntensity = maxIntensity;
+    void setTextureMaxIntensity(float maxIntensity) {
+        PhoXiInterface::textureMaxIntensity = maxIntensity;
+    }
+    /**
+     * Gets the CLAHE clip limit
+     */
+    double getTextureContrastLimitedAdaptiveHistogramEqualizationClipLimit() const {
+        return textureContrastLimitedAdaptiveHistogramEqualizationClipLimit;
+    }
+    /**
+     * Sets the CLAHE clip limit
+     */
+    void setTextureContrastLimitedAdaptiveHistogramEqualizationClipLimit(double claheClipLimit) {
+        PhoXiInterface::textureContrastLimitedAdaptiveHistogramEqualizationClipLimit = claheClipLimit;
+    }
+    /**
+     * Gets the number of bins in the X axis for CLAHE
+     */
+    int getTextureContrastLimitedAdaptiveHistogramEqualizationSizeX() const {
+        return textureContrastLimitedAdaptiveHistogramEqualizationSizeX;
+    }
+    /**
+     * Sets the number of bins in the X axis for CLAHE
+     */
+    void setTextureContrastLimitedAdaptiveHistogramEqualizationSizeX(int claheSizeX) {
+        PhoXiInterface::textureContrastLimitedAdaptiveHistogramEqualizationSizeX = claheSizeX;
+    }
+    /**
+     * Gets the number of bins in the Y axis for CLAHE
+     */
+    int getTextureContrastLimitedAdaptiveHistogramEqualizationSizeY() const {
+        return textureContrastLimitedAdaptiveHistogramEqualizationSizeY;
+    }
+    /**
+     * Sets the number of bins in the Y axis for CLAHE
+     */
+    void setTextureContrastLimitedAdaptiveHistogramEqualizationSizeY(int claheSizeY) {
+        PhoXiInterface::textureContrastLimitedAdaptiveHistogramEqualizationSizeY = claheSizeY;
     }
     /**
      * Gets the flag for specifying that only valid points should be used when
@@ -243,12 +294,12 @@ public:
 protected:
     pho::api::PPhoXi scanner;
     pho::api::PhoXiFactory phoXiFactory;
-    float minIntensity;
-    float maxIntensity;
+    float textureMinIntensity;
+    float textureMaxIntensity;
+    double textureContrastLimitedAdaptiveHistogramEqualizationClipLimit;
+    int textureContrastLimitedAdaptiveHistogramEqualizationSizeX;
+    int textureContrastLimitedAdaptiveHistogramEqualizationSizeY;
     bool generatePointCloudWithOnlyValidPoints;
-private:
-
-
 };
 
 

--- a/include/phoxi_camera/RosInterface.h
+++ b/include/phoxi_camera/RosInterface.h
@@ -40,8 +40,8 @@ class RosInterface : protected  PhoXiInterface {
 public:
     RosInterface();
 protected:
-    void publishFrame(pho::api::PFrame frame);
-    pho::api::PFrame getPFrame(int id = -1);
+    void publishFrame(PFramePostProcessed frame);
+    PFramePostProcessed getPFrame(int id = -1);
     int triggerImage();
     void connectCamera(std::string HWIdentification, pho::api::PhoXiTriggerMode mode = pho::api::PhoXiTriggerMode::Software, bool startAcquisition = true);
     std::string getTriggerMode(pho::api::PhoXiTriggerMode mode);

--- a/launch/phoxi_camera.launch
+++ b/launch/phoxi_camera.launch
@@ -6,5 +6,6 @@
     <node name="$(anon dynparam)" pkg="dynamic_reconfigure" type="dynparam" args="set_from_parameters phoxi_camera">
         <param name="min_intensity" type="double" value="0.0" />
         <param name="max_intensity" type="double" value="0.0" />
+        <param name="generate_point_cloud_with_only_valid_points" type="bool" value="false" />
     </node>
 </launch>

--- a/launch/phoxi_camera.launch
+++ b/launch/phoxi_camera.launch
@@ -1,5 +1,10 @@
 <launch>
-    <node pkg="phoxi_camera" type="phoxi_camera" name="phoxi_camera" output="screen">
+    <node pkg="phoxi_camera" type="phoxi_camera" name="phoxi_camera" output="screen" clear_params="true">
         <rosparam file="$(find phoxi_camera)/config/phoxi_camera.yaml" command="load"/>
+    </node>
+
+    <node name="$(anon dynparam)" pkg="dynamic_reconfigure" type="dynparam" args="set_from_parameters phoxi_camera">
+        <param name="min_intensity" type="double" value="0.0" />
+        <param name="max_intensity" type="double" value="0.0" />
     </node>
 </launch>

--- a/launch/phoxi_camera.launch
+++ b/launch/phoxi_camera.launch
@@ -4,8 +4,6 @@
     </node>
 
     <node name="$(anon dynparam)" pkg="dynamic_reconfigure" type="dynparam" args="set_from_parameters phoxi_camera">
-        <param name="min_intensity" type="double" value="0.0" />
-        <param name="max_intensity" type="double" value="0.0" />
         <param name="generate_point_cloud_with_only_valid_points" type="bool" value="false" />
     </node>
 </launch>

--- a/src/PhoXiInterface.cpp
+++ b/src/PhoXiInterface.cpp
@@ -50,7 +50,6 @@ void PhoXiInterface::connectCamera(std::string HWIdentification, pho::api::PhoXi
         throw UnableToStartAcquisition("Scanner was not able to connect. Disconnected.");
     }
     this->setTriggerMode(mode,startAcquisition);
-    return ;
 }
 void PhoXiInterface::disconnectCamera(){
     if(scanner && scanner->isConnected()){
@@ -95,13 +94,11 @@ void PhoXiInterface::isOk(){
     if(!scanner || !scanner->isConnected()){
         throw PhoXiScannerNotConnected("No scanner connected");
     }
-    return;
 }
 
 void PhoXiInterface::setCoordinateSpace(pho::api::PhoXiCoordinateSpace space){
     this->isOk();
     scanner->CoordinatesSettings->CoordinateSpace = space;
-    return;
 }
 
 pho::api::PhoXiCoordinateSpace PhoXiInterface::getCoordinateSpace(){

--- a/src/PhoXiInterface.cpp
+++ b/src/PhoXiInterface.cpp
@@ -94,11 +94,11 @@ std::shared_ptr<pcl::PointCloud<pcl::PointXYZRGBNormal>> PhoXiInterface::getPoin
             }
         }
     }
+    bool normalMapAvailable = scanner->OutputSettings->SendNormalMap && !frame->NormalMap.Empty();
     std::shared_ptr<pcl::PointCloud<pcl::PointXYZRGBNormal>> cloud(new pcl::PointCloud<pcl::PointXYZRGBNormal>(frame->GetResolution().Width,frame->GetResolution().Height));
     for(int r = 0; r < frame->GetResolution().Height; r++){
         for (int c = 0; c < frame->GetResolution().Width; c++){
             auto point = frame->PointCloud.At(r,c);
-            auto normal = frame->NormalMap.At(r,c);
             uint8_t intensity8Bits = 0;
             if (textureAvailable) {
                 float intensityMaxTruncated = std::min((float)frame->Texture.At(r,c), maxIntensity);
@@ -109,9 +109,12 @@ std::shared_ptr<pcl::PointCloud<pcl::PointXYZRGBNormal>> PhoXiInterface::getPoin
             pclPoint.x = point.x / 1000.0;
             pclPoint.y = point.y / 1000.0;
             pclPoint.z = point.z / 1000.0;
-            pclPoint.normal_x = normal.x;
-            pclPoint.normal_y = normal.y;
-            pclPoint.normal_z = normal.z;
+            if (normalMapAvailable) {
+                auto normal = frame->NormalMap.At(r,c);
+                pclPoint.normal_x = normal.x;
+                pclPoint.normal_y = normal.y;
+                pclPoint.normal_z = normal.z;
+            }
             pclPoint.r = intensity8Bits;
             pclPoint.g = intensity8Bits;
             pclPoint.b = intensity8Bits;

--- a/src/RosInterface.cpp
+++ b/src/RosInterface.cpp
@@ -253,22 +253,7 @@ void RosInterface::publishFrame(pho::api::PFrame frame) {
         ROS_WARN("NUll frame!");
         return;
     }
-    if (frame->PointCloud.Empty()){
-        ROS_WARN("Empty point cloud!");
-    }
-    if (frame->DepthMap.Empty()){
-        ROS_WARN("Empty depth map!");
-    }
-    if (frame->Texture.Empty()){
-        ROS_WARN("Empty texture!");
-    }
-    if (frame->ConfidenceMap.Empty()){
-        ROS_WARN("Empty confidence map!");
-    }
-    if (frame->NormalMap.Empty()){
-        ROS_WARN("Empty normal map!");
-    }
-    sensor_msgs::Image texture, confidence_map, normal_map, depth_map;
+
     ros::Time timeNow = ros::Time::now();
 
     std_msgs::Header header;
@@ -276,60 +261,93 @@ void RosInterface::publishFrame(pho::api::PFrame frame) {
     header.frame_id = frameId;
     header.seq = frame->Info.FrameIndex;
 
-    texture.header = header;
-    confidence_map.header = header;
-    normal_map.header = header;
-    depth_map.header = header;
+    if (scanner->OutputSettings->SendPointCloud) {
+        if (frame->PointCloud.Empty()){
+            ROS_WARN("Empty point cloud!");
+        } else {
+            auto cloud = PhoXiInterface::getPointCloudFromFrame(frame);
+            sensor_msgs::PointCloud2 output_cloud;
+            pcl::toROSMsg(*cloud,output_cloud);
+            output_cloud.header = header;
+            cloudPub.publish(output_cloud);
+        }
+    }
 
-    cv::Mat cvGreyTexture(frame->Texture.Size.Height, frame->Texture.Size.Width, CV_32FC1, frame->Texture.operator[](0));
-    cv::normalize(cvGreyTexture, cvGreyTexture, 0, 255, CV_MINMAX);
-    cvGreyTexture.convertTo(cvGreyTexture,CV_8U);
-    cv::equalizeHist(cvGreyTexture, cvGreyTexture);
-    cv::Mat cvRgbTexture;
-    cv::cvtColor(cvGreyTexture,cvRgbTexture,CV_GRAY2RGB);
-    cv_bridge::CvImage rgbTexture(header,sensor_msgs::image_encodings::BGR8,cvRgbTexture);
+    if (scanner->OutputSettings->SendDepthMap) {
+        if(frame->DepthMap.Empty()){
+            ROS_WARN("Empty depth map!");
+        } else {
+            sensor_msgs::Image depth_map;
+            depth_map.header = header;
+            depth_map.encoding = sensor_msgs::image_encodings::TYPE_32FC1;
+            sensor_msgs::fillImage(depth_map,
+                                   sensor_msgs::image_encodings::TYPE_32FC1,
+                                   frame->DepthMap.Size.Height, // height
+                                   frame->DepthMap.Size.Width, // width
+                                   frame->DepthMap.Size.Width * sizeof(float), // stepSize
+                                   frame->DepthMap.operator[](0));
+            depthMapPub.publish(depth_map);
+        }
+    }
 
-    texture.encoding = sensor_msgs::image_encodings::TYPE_32FC1;
-    sensor_msgs::fillImage(texture, sensor_msgs::image_encodings::TYPE_32FC1,
-                           frame->Texture.Size.Height, // height
-                           frame->Texture.Size.Width, // width
-                           frame->Texture.Size.Width * sizeof(float), // stepSize
-                           frame->Texture.operator[](0));
-    confidence_map.encoding = sensor_msgs::image_encodings::TYPE_32FC1;
-    sensor_msgs::fillImage(confidence_map,
-                           sensor_msgs::image_encodings::TYPE_32FC1,
-                           frame->ConfidenceMap.Size.Height, // height
-                           frame->ConfidenceMap.Size.Width, // width
-                           frame->ConfidenceMap.Size.Width * sizeof(float), // stepSize
-                           frame->ConfidenceMap.operator[](0));
-    normal_map.encoding = sensor_msgs::image_encodings::TYPE_32FC3;
-    sensor_msgs::fillImage(normal_map,
-                           sensor_msgs::image_encodings::TYPE_32FC3,
-                           frame->NormalMap.Size.Height, // height
-                           frame->NormalMap.Size.Width, // width
-                           frame->NormalMap.Size.Width * sizeof(float) * 3, // stepSize
-                           frame->NormalMap.operator[](0));
-    depth_map.encoding = sensor_msgs::image_encodings::TYPE_32FC1;
-    sensor_msgs::fillImage(depth_map,
-                           sensor_msgs::image_encodings::TYPE_32FC1,
-                           frame->DepthMap.Size.Height, // height
-                           frame->DepthMap.Size.Width, // width
-                           frame->DepthMap.Size.Width * sizeof(float), // stepSize
-                           frame->DepthMap.operator[](0));
-    std::shared_ptr<pcl::PointCloud<pcl::PointNormal>> cloud = PhoXiInterface::getPointCloudFromFrame(frame);
+    if (scanner->OutputSettings->SendTexture) {
+        if (frame->Texture.Empty()) {
+            ROS_WARN("Empty texture!");
+        } else {
+            sensor_msgs::Image texture;
+            texture.header = header;
+            texture.encoding = sensor_msgs::image_encodings::TYPE_32FC1;
+            sensor_msgs::fillImage(texture, sensor_msgs::image_encodings::TYPE_32FC1,
+                                   frame->Texture.Size.Height, // height
+                                   frame->Texture.Size.Width, // width
+                                   frame->Texture.Size.Width * sizeof(float), // stepSize
+                                   frame->Texture.operator[](0));
+            rawTexturePub.publish(texture);
 
-    sensor_msgs::PointCloud2 output_cloud;
-    pcl::toROSMsg(*cloud,output_cloud);
-    output_cloud.header.frame_id = frameId;
-    output_cloud.header.stamp = timeNow;
-    output_cloud.header.seq = frame->Info.FrameIndex;
+            cv::Mat cvGreyTexture(frame->Texture.Size.Height, frame->Texture.Size.Width, CV_32FC1, frame->Texture.operator[](0));
+            cv::normalize(cvGreyTexture, cvGreyTexture, 0, 255, CV_MINMAX);
+            cvGreyTexture.convertTo(cvGreyTexture, CV_8U);
+            cv::equalizeHist(cvGreyTexture, cvGreyTexture);
+            cv::Mat cvRgbTexture;
+            cv::cvtColor(cvGreyTexture, cvRgbTexture, CV_GRAY2RGB);
+            cv_bridge::CvImage rgbTexture(header, sensor_msgs::image_encodings::BGR8, cvRgbTexture);
+            rgbTexturePub.publish(rgbTexture.toImageMsg());
+        }
+    }
 
-    cloudPub.publish(output_cloud);
-    normalMapPub.publish(normal_map);
-    confidenceMapPub.publish(confidence_map);
-    rawTexturePub.publish(texture);
-    rgbTexturePub.publish(rgbTexture.toImageMsg());
-    depthMapPub.publish(depth_map);
+    if (scanner->OutputSettings->SendConfidenceMap) {
+        if (frame->ConfidenceMap.Empty()){
+            ROS_WARN("Empty confidence map!");
+        } else {
+            sensor_msgs::Image confidence_map;
+            confidence_map.header = header;
+            confidence_map.encoding = sensor_msgs::image_encodings::TYPE_32FC1;
+            sensor_msgs::fillImage(confidence_map,
+                                   sensor_msgs::image_encodings::TYPE_32FC1,
+                                   frame->ConfidenceMap.Size.Height, // height
+                                   frame->ConfidenceMap.Size.Width, // width
+                                   frame->ConfidenceMap.Size.Width * sizeof(float), // stepSize
+                                   frame->ConfidenceMap.operator[](0));
+            confidenceMapPub.publish(confidence_map);
+        }
+    }
+
+    if (scanner->OutputSettings->SendNormalMap) {
+        if (frame->NormalMap.Empty()){
+            ROS_WARN("Empty normal map!");
+        } else {
+            sensor_msgs::Image normal_map;
+            normal_map.header = header;
+            normal_map.encoding = sensor_msgs::image_encodings::TYPE_32FC3;
+            sensor_msgs::fillImage(normal_map,
+                                   sensor_msgs::image_encodings::TYPE_32FC3,
+                                   frame->NormalMap.Size.Height, // height
+                                   frame->NormalMap.Size.Width, // width
+                                   frame->NormalMap.Size.Width * sizeof(float) * 3, // stepSize
+                                   frame->NormalMap.operator[](0));
+            normalMapPub.publish(normal_map);
+        }
+    }
 }
 
 bool RosInterface::setCoordianteSpace(phoxi_camera::SetCoordinatesSpace::Request &req, phoxi_camera::SetCoordinatesSpace::Response &res){

--- a/src/RosInterface.cpp
+++ b/src/RosInterface.cpp
@@ -539,6 +539,16 @@ void RosInterface::dynamicReconfigureCallback(phoxi_camera::phoxi_cameraConfig &
             ROS_WARN("%s",e.what());
         }
     }
+
+    if (level & (1 << 15)) {
+        try{
+            this->isOk();
+            PhoXiInterface::setGeneratePointCloudWithOnlyValidPoints(config.generate_point_cloud_with_only_valid_points);
+            this->dynamicReconfigureConfig.generate_point_cloud_with_only_valid_points = config.generate_point_cloud_with_only_valid_points;
+        }catch (PhoXiInterfaceException &e){
+            ROS_WARN("%s",e.what());
+        }
+    }
 }
 
 pho::api::PFrame RosInterface::getPFrame(int id){

--- a/src/RosInterface.cpp
+++ b/src/RosInterface.cpp
@@ -392,9 +392,11 @@ void RosInterface::dynamicReconfigureCallback(phoxi_camera::phoxi_cameraConfig &
             switch (config.resolution){
                 case 0:
                     PhoXiInterface::setLowResolution();
+                    this->dynamicReconfigureConfig.resolution = config.resolution;
                     break;
                 case 1:
                     PhoXiInterface::setHighResolution();
+                    this->dynamicReconfigureConfig.resolution = config.resolution;
                     break;
                 default:
                     ROS_WARN("Resolution not supported!");
@@ -409,6 +411,7 @@ void RosInterface::dynamicReconfigureCallback(phoxi_camera::phoxi_cameraConfig &
         try{
             this->isOk();
             scanner->CapturingSettings->ScanMultiplier = config.scan_multiplier;
+            this->dynamicReconfigureConfig.scan_multiplier = config.scan_multiplier;
         }catch (PhoXiInterfaceException &e){
             ROS_WARN("%s",e.what());
         }
@@ -418,6 +421,7 @@ void RosInterface::dynamicReconfigureCallback(phoxi_camera::phoxi_cameraConfig &
         try{
             this->isOk();
             scanner->CapturingSettings->ShutterMultiplier = config.shutter_multiplier;
+            this->dynamicReconfigureConfig.shutter_multiplier = config.shutter_multiplier;
         }catch (PhoXiInterfaceException &e){
             ROS_WARN("%s",e.what());
         }
@@ -426,6 +430,8 @@ void RosInterface::dynamicReconfigureCallback(phoxi_camera::phoxi_cameraConfig &
     if (level & (1 << 4)) {
         try{
             PhoXiInterface::setTriggerMode(config.trigger_mode,config.start_acquisition);
+            this->dynamicReconfigureConfig.trigger_mode = config.trigger_mode;
+            this->dynamicReconfigureConfig.start_acquisition = config.start_acquisition;
         }catch (PhoXiInterfaceException &e){
             ROS_WARN("%s",e.what());
         }
@@ -435,6 +441,7 @@ void RosInterface::dynamicReconfigureCallback(phoxi_camera::phoxi_cameraConfig &
         try{
             this->isOk();
             scanner->Timeout = config.timeout;
+            this->dynamicReconfigureConfig.timeout = config.timeout;
         }catch (PhoXiInterfaceException &e){
             ROS_WARN("%s",e.what());
         }
@@ -444,6 +451,7 @@ void RosInterface::dynamicReconfigureCallback(phoxi_camera::phoxi_cameraConfig &
         try{
             this->isOk();
             scanner->ProcessingSettings->Confidence = config.confidence;
+            this->dynamicReconfigureConfig.confidence = config.confidence;
         }catch (PhoXiInterfaceException &e){
             ROS_WARN("%s",e.what());
         }
@@ -453,6 +461,7 @@ void RosInterface::dynamicReconfigureCallback(phoxi_camera::phoxi_cameraConfig &
         try{
             this->isOk();
             scanner->OutputSettings->SendPointCloud = config.send_point_cloud;
+            this->dynamicReconfigureConfig.send_point_cloud = config.send_point_cloud;
         }catch (PhoXiInterfaceException &e){
             ROS_WARN("%s",e.what());
         }
@@ -462,6 +471,7 @@ void RosInterface::dynamicReconfigureCallback(phoxi_camera::phoxi_cameraConfig &
         try{
             this->isOk();
             scanner->OutputSettings->SendNormalMap = config.send_normal_map;
+            this->dynamicReconfigureConfig.send_normal_map = config.send_normal_map;
         }catch (PhoXiInterfaceException &e){
             ROS_WARN("%s",e.what());
         }
@@ -471,6 +481,7 @@ void RosInterface::dynamicReconfigureCallback(phoxi_camera::phoxi_cameraConfig &
         try{
             this->isOk();
             scanner->OutputSettings->SendConfidenceMap = config.send_confidence_map;
+            this->dynamicReconfigureConfig.send_confidence_map = config.send_confidence_map;
         }catch (PhoXiInterfaceException &e){
             ROS_WARN("%s",e.what());
         }
@@ -480,6 +491,7 @@ void RosInterface::dynamicReconfigureCallback(phoxi_camera::phoxi_cameraConfig &
         try{
             this->isOk();
             scanner->OutputSettings->SendTexture = config.send_texture;
+            this->dynamicReconfigureConfig.send_texture = config.send_texture;
         }catch (PhoXiInterfaceException &e){
             ROS_WARN("%s",e.what());
         }
@@ -488,7 +500,18 @@ void RosInterface::dynamicReconfigureCallback(phoxi_camera::phoxi_cameraConfig &
     if (level & (1 << 11)) {
         try{
             this->isOk();
-            scanner->OutputSettings->SendTexture = config.send_deapth_map;
+            scanner->OutputSettings->SendDepthMap = config.send_deapth_map;
+            this->dynamicReconfigureConfig.send_deapth_map = config.send_deapth_map;
+        }catch (PhoXiInterfaceException &e){
+            ROS_WARN("%s",e.what());
+        }
+    }
+
+    if (level & (1 << 12)) {
+        try{
+            this->isOk();
+            PhoXiInterface::setCoordinateSpace(config.coordination_space);
+            this->dynamicReconfigureConfig.coordination_space = config.coordination_space;
         }catch (PhoXiInterfaceException &e){
             ROS_WARN("%s",e.what());
         }
@@ -498,7 +521,7 @@ void RosInterface::dynamicReconfigureCallback(phoxi_camera::phoxi_cameraConfig &
 pho::api::PFrame RosInterface::getPFrame(int id){
     pho::api::PFrame frame = PhoXiInterface::getPFrame(id);
     //update dynamic reconfigure
-    dynamicReconfigureConfig.coordination_space = pho::api::PhoXiTriggerMode::Software;
+    dynamicReconfigureConfig.trigger_mode = pho::api::PhoXiTriggerMode::Software;
     dynamicReconfigureServer.updateConfig(dynamicReconfigureConfig);
     return frame;
 }
@@ -506,7 +529,7 @@ pho::api::PFrame RosInterface::getPFrame(int id){
 int RosInterface::triggerImage(){
     int id = PhoXiInterface::triggerImage();
     //update dynamic reconfigure
-    dynamicReconfigureConfig.coordination_space = pho::api::PhoXiTriggerMode::Software;
+    dynamicReconfigureConfig.trigger_mode = pho::api::PhoXiTriggerMode::Software;
     dynamicReconfigureServer.updateConfig(dynamicReconfigureConfig);
     return id;
 }

--- a/src/RosInterface.cpp
+++ b/src/RosInterface.cpp
@@ -57,7 +57,7 @@ RosInterface::RosInterface() : nh("~"), dynamicReconfigureServer(dynamicReconfig
 
     //connect to default scanner
     std::string scannerId;
-    nh.param<std::string>("scanner_id", scannerId, "InstalledExamples-PhoXi-example");
+    nh.param<std::string>("scanner_id", scannerId, "InstalledExamples-basic-example");
     nh.param<std::string>("frame_id", frameId, "PhoXi3Dscanner_sensor");
 
     try {

--- a/src/RosInterface.cpp
+++ b/src/RosInterface.cpp
@@ -35,16 +35,16 @@ RosInterface::RosInterface() : nh("~"), dynamicReconfigureServer(dynamicReconfig
     setTransformationService = nh.advertiseService("V2/set_coordination_space",&RosInterface::setCoordianteSpace, this);
 
     //create publishers
-    bool latch_tipics;
+    bool latch_topics;
     int topic_queue_size;
-    nh.param<bool>("latch_tipics", latch_tipics, false);
+    nh.param<bool>("latch_topics", latch_topics, false);
     nh.param<int>("topic_queue_size", topic_queue_size, 1);
-    cloudPub = nh.advertise <pcl::PointCloud<pcl::PointXYZ >>("pointcloud", 1,latch_tipics);
-    normalMapPub = nh.advertise < sensor_msgs::Image > ("normal_map", topic_queue_size,latch_tipics);
-    confidenceMapPub = nh.advertise < sensor_msgs::Image > ("confidence_map", topic_queue_size,latch_tipics);
-    rawTexturePub = nh.advertise < sensor_msgs::Image > ("texture", topic_queue_size,latch_tipics);
-    rgbTexturePub = nh.advertise < sensor_msgs::Image > ("rgb_texture", topic_queue_size,latch_tipics);
-    depthMapPub = nh.advertise < sensor_msgs::Image > ("depth_map", topic_queue_size,latch_tipics);
+    cloudPub = nh.advertise <pcl::PointCloud<pcl::PointXYZ >>("pointcloud", 1,latch_topics);
+    normalMapPub = nh.advertise < sensor_msgs::Image > ("normal_map", topic_queue_size,latch_topics);
+    confidenceMapPub = nh.advertise < sensor_msgs::Image > ("confidence_map", topic_queue_size,latch_topics);
+    rawTexturePub = nh.advertise < sensor_msgs::Image > ("texture", topic_queue_size,latch_topics);
+    rgbTexturePub = nh.advertise < sensor_msgs::Image > ("rgb_texture", topic_queue_size,latch_topics);
+    depthMapPub = nh.advertise < sensor_msgs::Image > ("depth_map", topic_queue_size,latch_topics);
 
     //set dynamic reconfigure callback
     dynamicReconfigureServer.setCallback(boost::bind(&RosInterface::dynamicReconfigureCallback,this, _1, _2));

--- a/src/RosInterface.cpp
+++ b/src/RosInterface.cpp
@@ -266,6 +266,9 @@ void RosInterface::publishFrame(pho::api::PFrame frame) {
             ROS_WARN("Empty point cloud!");
         } else {
             auto cloud = PhoXiInterface::getPointCloudFromFrame(frame);
+            dynamicReconfigureConfig.min_intensity = getMinIntensity();
+            dynamicReconfigureConfig.max_intensity = getMaxIntensity();
+            dynamicReconfigureServer.updateConfig(dynamicReconfigureConfig);
             sensor_msgs::PointCloud2 output_cloud;
             pcl::toROSMsg(*cloud,output_cloud);
             output_cloud.header = header;
@@ -512,6 +515,26 @@ void RosInterface::dynamicReconfigureCallback(phoxi_camera::phoxi_cameraConfig &
             this->isOk();
             PhoXiInterface::setCoordinateSpace(config.coordination_space);
             this->dynamicReconfigureConfig.coordination_space = config.coordination_space;
+        }catch (PhoXiInterfaceException &e){
+            ROS_WARN("%s",e.what());
+        }
+    }
+
+    if (level & (1 << 13)) {
+        try{
+            this->isOk();
+            PhoXiInterface::setMinIntensity((float)config.min_intensity);
+            this->dynamicReconfigureConfig.min_intensity = config.min_intensity;
+        }catch (PhoXiInterfaceException &e){
+            ROS_WARN("%s",e.what());
+        }
+    }
+
+    if (level & (1 << 14)) {
+        try{
+            this->isOk();
+            PhoXiInterface::setMaxIntensity((float)config.max_intensity);
+            this->dynamicReconfigureConfig.max_intensity = config.max_intensity;
         }catch (PhoXiInterfaceException &e){
             ROS_WARN("%s",e.what());
         }

--- a/test/gtest/test_phoxi_interface.cpp
+++ b/test/gtest/test_phoxi_interface.cpp
@@ -224,14 +224,14 @@ TEST_F (PhoXiInterfaceTest, setTriggerMode) {
 TEST_F (PhoXiInterfaceTest, setResolution) {
 
     ASSERT_NO_THROW(phoxi_interface.setHighResolution());
-    pho::api::PFrame f = phoxi_interface.getPFrame(-1);
-    ASSERT_EQ(f->GetResolution().Width,2064);
-    ASSERT_EQ(f->GetResolution().Height,1544);
+    PFramePostProcessed f = phoxi_interface.getPFrame(-1);
+    ASSERT_EQ(f->PFrame->GetResolution().Width,2064);
+    ASSERT_EQ(f->PFrame->GetResolution().Height,1544);
 
     ASSERT_NO_THROW(phoxi_interface.setLowResolution());
     f = phoxi_interface.getPFrame(-1);
-    ASSERT_EQ(f->GetResolution().Width,1032);
-    ASSERT_EQ(f->GetResolution().Height,772);
+    ASSERT_EQ(f->PFrame->GetResolution().Width,1032);
+    ASSERT_EQ(f->PFrame->GetResolution().Height,772);
 
     // try it without connection to camera
     phoxi_interface.disconnectCamera();
@@ -370,7 +370,6 @@ TEST_F (PhoXiInterfaceTest, setCoordinateSpace) {
 
 TEST_F (PhoXiInterfaceTest, getPFrame) {
     int bad_frameID = 1123;
-    pho::api::PFrame frame;
 
     // trigger image and get PFrame
     int frameID = phoxi_interface.triggerImage();
@@ -390,7 +389,7 @@ TEST_F (PhoXiInterfaceTest, getPFrame) {
 TEST_F (PhoXiInterfaceTest, getPointCloudFromFrame) {
     ASSERT_THROW(phoxi_interface.getPointCloudFromFrame(nullptr), CorruptedFrame);
 
-    pho::api::PFrame frame;
+    PFramePostProcessed frame;
     frame = phoxi_interface.getPFrame(-1);
     ASSERT_NE(nullptr, phoxi_interface.getPointCloudFromFrame(frame));
 


### PR DESCRIPTION
Added the option to use CLAHE (contrast limited adaptive histogram equalization) for improving the image texture.
Now the texture published to ROS and used in the coloring of the point cloud can have manual or automatic normalization and can also use CLAHE (check the comments in cfg/phoxi_camera.cfg please).

This PR includes all the commits of the previous pull requests I have submitted recently.
I could not submit a new PR or use previous PRs because the last commit with the addition of the CLAHE required changes from several PRs.
I also noticed that a new branch (carlosmccosta-improvements) with all the PRs I have submitted was created, probably because it makes it easier to test all of them at the same time.
As such, for making the testing of all my PRs faster and easier, this PR includes all the improvements I made to this driver so far.