### PR TITLE
Fix unit and interface tests for phoxi_camera

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -3,8 +3,10 @@
 * Installed PhoXi Control
 * Installed pytest: sudo apt-get install python-pytest
 
-Before run of tests set scanner ID or file camera ID in the **interfaces/config.py**, 
-it is needed for connect to camera. Default file camera ID for testing is "InstalledExamples-PhoXi-example".
+Before run of tests set ID of real scanner in the **interfaces/config.py** for pytest and in the
+**gtest/test_phoxi_api_interface.cpp** for unittests, it is needed for connect to camera.
+Default camera ID for testing is file camera "InstalledExamples-PhoXi-example", but is strongly
+recommended to use real camera for testing purposes.
 
 
 ## Compile and run tests
@@ -51,7 +53,6 @@ tested node and perform tests.
 
 ## Troubleshooting
 
-You don't run python tests using command `catkin_make run_tests_phoxi_camera_...` 
-but via `rostest phoxi_camera test_name`.
-If tests are failed in setUpClass restart PhoXiControl or better kill and 
-remove your docker and create new. 
+You don't run python tests using command `catkin_make run_tests_phoxi_camera_...`
+but via `rostest phoxi_camera <test_name>`.
+If tests are failed in setUpClass, you should try to restart PhoXiControl.

--- a/test/README.md
+++ b/test/README.md
@@ -48,3 +48,10 @@ In this special launch file is included tested launch file which runs
 target ros node and load parameters. The special launch file also launch
 testing node which consist of python unittests, this node interact with
 tested node and perform tests.
+
+## Troubleshooting
+
+You don't run python tests using command `catkin_make run_tests_phoxi_camera_...` 
+but via `rostest phoxi_camera test_name`.
+If tests are failed in setUpClass restart PhoXiControl or better kill and 
+remove your docker and create new. 

--- a/test/gtest/test_phoxi_api_interface.cpp
+++ b/test/gtest/test_phoxi_api_interface.cpp
@@ -15,11 +15,10 @@
 using namespace std;
 phoxi_camera::PhoXiInterface phoxi_interface;
 long sleepPhoXiFactory = 1500000;
+const string camera_ID = "InstalledExamples-basic-example";
 
 class PhoXiInterfaceTest : public testing::Test {
 public:
-    const string camera_ID = "InstalledExamples-basic-example";
-
     static void SetUpTestCase(){
         //test constructor only once
         //ASSERT_NO_THROW(PhoXiInterface());
@@ -37,7 +36,6 @@ public:
 
 class PhoXiInterfaceTestConnection : public testing::Test {
 public:
-    const string camera_ID = "InstalledExamples-basic-example";
     //PhoXiInterface phoxi_interface;
 
     static void SetUpTestCase(){

--- a/test/gtest/test_phoxi_api_interface.cpp
+++ b/test/gtest/test_phoxi_api_interface.cpp
@@ -13,7 +13,8 @@
 #include <vector>
 
 using namespace std;
-PhoXiInterface phoxi_interface;
+phoxi_camera::PhoXiInterface phoxi_interface;
+long sleepPhoXiFactory = 1500000;
 
 class PhoXiInterfaceTest : public testing::Test {
 public:
@@ -25,11 +26,12 @@ public:
     }
 
     virtual void SetUp() {
+        usleep(sleepPhoXiFactory);
         phoxi_interface.connectCamera(camera_ID);
+        usleep(sleepPhoXiFactory);
     }
 
     virtual void TearDown() {
-        phoxi_interface.disconnectCamera();
     }
 };
 
@@ -44,7 +46,9 @@ public:
     }
 
     virtual void TearDown() {
+        usleep(sleepPhoXiFactory);
         phoxi_interface.disconnectCamera();
+        usleep(sleepPhoXiFactory);
     }
 };
 
@@ -54,9 +58,9 @@ TEST_F (PhoXiInterfaceTestConnection, connect) {
     string incorrect_camera_ID = "000000";
 
     // try to connect to unreachable scanner
-    ASSERT_THROW(phoxi_interface.connectCamera(incorrect_camera_ID), PhoXiScannerNotFound);
+    ASSERT_THROW(phoxi_interface.connectCamera(incorrect_camera_ID), phoxi_camera::PhoXiScannerNotFound);
     ASSERT_FALSE(phoxi_interface.isConnected());
-    EXPECT_THROW(phoxi_interface.isOk(), PhoXiScannerNotConnected);
+    EXPECT_THROW(phoxi_interface.isOk(), phoxi_camera::PhoXiScannerNotConnected);
 
     //  try to connect to reachable scanner
     ASSERT_NO_THROW(phoxi_interface.connectCamera(camera_ID));
@@ -69,7 +73,7 @@ TEST_F (PhoXiInterfaceTestConnection, connect) {
     ASSERT_NO_THROW(phoxi_interface.isOk());
 
     // I am connected to scanner, now try to connect to unreachable scanner
-    ASSERT_THROW(phoxi_interface.connectCamera(incorrect_camera_ID), PhoXiScannerNotFound);
+    ASSERT_THROW(phoxi_interface.connectCamera(incorrect_camera_ID), phoxi_camera::PhoXiScannerNotFound);
     ASSERT_TRUE(phoxi_interface.isConnected());     // I am still connected to previous scanner
     ASSERT_NO_THROW(phoxi_interface.isOk());
 
@@ -102,11 +106,11 @@ TEST_F (PhoXiInterfaceTestConnection, disconnect) {
     phoxi_interface.connectCamera(camera_ID);
     ASSERT_NO_THROW(phoxi_interface.isOk());
     ASSERT_NO_THROW(phoxi_interface.disconnectCamera());
-    ASSERT_THROW(phoxi_interface.isOk(), PhoXiScannerNotConnected);
+    ASSERT_THROW(phoxi_interface.isOk(), phoxi_camera::PhoXiScannerNotConnected);
 
     // try disconnect camera when I am disconnected
     ASSERT_NO_THROW(phoxi_interface.disconnectCamera());
-    ASSERT_THROW(phoxi_interface.isOk(), PhoXiScannerNotConnected);
+    ASSERT_THROW(phoxi_interface.isOk(), phoxi_camera::PhoXiScannerNotConnected);
 }
 
 TEST_F (PhoXiInterfaceTest, isOK) {
@@ -116,7 +120,7 @@ TEST_F (PhoXiInterfaceTest, isOK) {
 
     phoxi_interface.disconnectCamera();
 
-    ASSERT_THROW(phoxi_interface.isOk(), PhoXiScannerNotConnected);
+    ASSERT_THROW(phoxi_interface.isOk(), phoxi_camera::PhoXiScannerNotConnected);
 
     // TODO call isOK when PhoXi is off
 }
@@ -155,8 +159,8 @@ TEST_F (PhoXiInterfaceTest, start_stopAcquisition) {
 
     // after disconnect
     phoxi_interface.disconnectCamera();
-    ASSERT_THROW(phoxi_interface.startAcquisition(), PhoXiScannerNotConnected);
-    ASSERT_THROW(phoxi_interface.stopAcquisition(), PhoXiScannerNotConnected);
+    ASSERT_THROW(phoxi_interface.startAcquisition(), phoxi_camera::PhoXiScannerNotConnected);
+    ASSERT_THROW(phoxi_interface.stopAcquisition(), phoxi_camera::PhoXiScannerNotConnected);
 }
 
 TEST_F (PhoXiInterfaceTest, setTriggerMode) {
@@ -213,12 +217,12 @@ TEST_F (PhoXiInterfaceTest, setTriggerMode) {
 
     // incorrect parameters
     phoxi_interface.stopAcquisition();
-    ASSERT_THROW(phoxi_interface.setTriggerMode(-1,true),InvalidTriggerMode);
+    ASSERT_THROW(phoxi_interface.setTriggerMode(-1,true),phoxi_camera::InvalidTriggerMode);
     EXPECT_FALSE(phoxi_interface.isAcquiring());
 
     // try it without connection to camera
     phoxi_interface.disconnectCamera();
-    ASSERT_THROW(phoxi_interface.setTriggerMode(pho::api::PhoXiTriggerMode::Software), PhoXiScannerNotConnected);
+    ASSERT_THROW(phoxi_interface.setTriggerMode(pho::api::PhoXiTriggerMode::Software), phoxi_camera::PhoXiScannerNotConnected);
 }
 
 TEST_F (PhoXiInterfaceTest, setResolution) {
@@ -235,8 +239,8 @@ TEST_F (PhoXiInterfaceTest, setResolution) {
 
     // try it without connection to camera
     phoxi_interface.disconnectCamera();
-    ASSERT_THROW(phoxi_interface.setLowResolution(), PhoXiScannerNotConnected);
-    ASSERT_THROW(phoxi_interface.setHighResolution(), PhoXiScannerNotConnected);
+    ASSERT_THROW(phoxi_interface.setLowResolution(), phoxi_camera::PhoXiScannerNotConnected);
+    ASSERT_THROW(phoxi_interface.setHighResolution(), phoxi_camera::PhoXiScannerNotConnected);
 }
 
 TEST_F (PhoXiInterfaceTest, triggerImage) {
@@ -273,7 +277,7 @@ TEST_F (PhoXiInterfaceTest, triggerImage) {
 
     // try it without connection to camera
     phoxi_interface.disconnectCamera();
-    ASSERT_THROW(phoxi_interface.triggerImage(), PhoXiScannerNotConnected);
+    ASSERT_THROW(phoxi_interface.triggerImage(), phoxi_camera::PhoXiScannerNotConnected);
 }
 
 TEST_F (PhoXiInterfaceTest, getHardwareIdentification) {
@@ -282,7 +286,7 @@ TEST_F (PhoXiInterfaceTest, getHardwareIdentification) {
 
     // try it without connection to camera
     phoxi_interface.disconnectCamera();
-    ASSERT_THROW(phoxi_interface.getHardwareIdentification(), PhoXiScannerNotConnected);
+    ASSERT_THROW(phoxi_interface.getHardwareIdentification(), phoxi_camera::PhoXiScannerNotConnected);
 }
 
 TEST_F (PhoXiInterfaceTest, setTransformation) {
@@ -321,14 +325,14 @@ TEST_F (PhoXiInterfaceTest, setTransformation) {
     // MarkerSpace
     EXPECT_THROW(phoxi_interface.setTransformation(transformation,
                                                    pho::api::PhoXiCoordinateSpace::MarkerSpace,
-                                                   true, false), CoordinateSpaceNotSupported);
+                                                   true, false), phoxi_camera::CoordinateSpaceNotSupported);
     ASSERT_NO_THROW(phoxi_interface.triggerImage());
 
     // try it without connected camera
     phoxi_interface.disconnectCamera();
     ASSERT_THROW(phoxi_interface.setTransformation(transformation,
                                                    pho::api::PhoXiCoordinateSpace::CustomSpace,
-                                                   true, false), PhoXiScannerNotConnected);
+                                                   true, false), phoxi_camera::PhoXiScannerNotConnected);
 }
 
 TEST_F (PhoXiInterfaceTest, setCoordinateSpace) {
@@ -356,7 +360,7 @@ TEST_F (PhoXiInterfaceTest, setCoordinateSpace) {
     // try it without connection to camera
     phoxi_interface.disconnectCamera();
     ASSERT_THROW(phoxi_interface.setCoordinateSpace(pho::api::PhoXiCoordinateSpace::RobotSpace),
-                 PhoXiScannerNotConnected);
+                 phoxi_camera::PhoXiScannerNotConnected);
 }
 
 TEST_F (PhoXiInterfaceTest, getPFrame) {
@@ -375,11 +379,11 @@ TEST_F (PhoXiInterfaceTest, getPFrame) {
 
     // try it without connection to camera
     phoxi_interface.disconnectCamera();
-    ASSERT_THROW(phoxi_interface.getPFrame(-1), PhoXiScannerNotConnected);
+    ASSERT_THROW(phoxi_interface.getPFrame(-1), phoxi_camera::PhoXiScannerNotConnected);
 }
 
 TEST_F (PhoXiInterfaceTest, getPointCloudFromFrame) {
-    ASSERT_THROW(phoxi_interface.getPointCloudFromFrame(nullptr), CorruptedFrame);
+    ASSERT_THROW(phoxi_interface.getPointCloudFromFrame(nullptr), phoxi_camera::CorruptedFrame);
 
     pho::api::PFrame frame;
     frame = phoxi_interface.getPFrame(-1);
@@ -397,7 +401,7 @@ TEST_F (PhoXiInterfaceTest, getPointCloud) {
 
     // try it without connection to camera
     phoxi_interface.disconnectCamera();
-    ASSERT_THROW(phoxi_interface.getPointCloud(), PhoXiScannerNotConnected);
+    ASSERT_THROW(phoxi_interface.getPointCloud(), phoxi_camera::PhoXiScannerNotConnected);
 }
 
 TEST_F (PhoXiInterfaceTest, getSupportedCapturingModes) {
@@ -411,7 +415,7 @@ TEST_F (PhoXiInterfaceTest, getSupportedCapturingModes) {
 
     // try it without connection to camera
     phoxi_interface.disconnectCamera();
-    ASSERT_THROW(phoxi_interface.getSupportedCapturingModes(), PhoXiScannerNotConnected);
+    ASSERT_THROW(phoxi_interface.getSupportedCapturingModes(), phoxi_camera::PhoXiScannerNotConnected);
 }
 
 TEST_F (PhoXiInterfaceTest, cameraList) {

--- a/test/interfaces/test_phoxi_camera_ros_interfaces.py
+++ b/test/interfaces/test_phoxi_camera_ros_interfaces.py
@@ -208,7 +208,7 @@ class Test_phoxi_camera_ros_interface(TestCase):
         assert True == res.success
         assert "Ok" == res.message
         assert published_topics_num == 4, "Some topic was not published after get_frame service"
-
+        # Todo confidence map is mepty
         # disconnected
         disconnect()
         res = srv_getFrame(-1)
@@ -220,7 +220,7 @@ class Test_phoxi_camera_ros_interface(TestCase):
         import os
         path = os.getcwd()  # it should be ~/.ros
         filename = "/file.ply"
-        os.system("rm " + path + filename)  # remove old file
+        os.system("rm -f " + path + filename)  # remove old file
 
         dir = os.listdir(path)
 
@@ -232,7 +232,7 @@ class Test_phoxi_camera_ros_interface(TestCase):
         assert True == res.success
         assert "Ok" == res.message
 
-        os.system("rm " + path + filename)  # remove created file
+        os.system("rm -f " + path + filename)  # remove created file
 
     def test_getHardwareIdentification(self):
         # connected
@@ -319,7 +319,7 @@ class Test_phoxi_camera_ros_interface(TestCase):
 
         path = os.getcwd() + '/'
         filenames = ["file.ply", "file.praw", "file.ptx"]
-        os.system("rm " + path + "*.ply " + path + "*.praw " + path + "*.ptx")  # remove old file if exist
+        os.system("rm -f " + path + "*.ply " + path + "*.praw " + path + "*.ptx")  # remove old file if exist
 
         for file in filenames:
             dir = os.listdir(path) # record files in directory
@@ -330,7 +330,7 @@ class Test_phoxi_camera_ros_interface(TestCase):
             assert dir.pop() == file
             assert True == res.success
             assert "Ok" == res.message
-            os.system("rm " + path + file)  # remove created file
+            os.system("rm -f " + path + file)  # remove created file
 
 
 if __name__ == '__main__':

--- a/test/interfaces/test_phoxi_camera_ros_interfaces.py
+++ b/test/interfaces/test_phoxi_camera_ros_interfaces.py
@@ -208,7 +208,6 @@ class Test_phoxi_camera_ros_interface(TestCase):
         assert True == res.success
         assert "Ok" == res.message
         assert published_topics_num == 4, "Some topic was not published after get_frame service"
-        # Todo confidence map is mepty
         # disconnected
         disconnect()
         res = srv_getFrame(-1)


### PR DESCRIPTION
First I fixed unit test. There is still problem with instantiate of phoXiFactory. I "solved" this problem with usleep(). 

Second when you run test_ros_interface via command 'rostest' there was problem with removing temporary files. So I changed it to 'force remove' (rm -f).