### PR TITLE
avahi err handling BIPI-2737 BIPI-2716

### DIFF
--- a/include/phoxi_camera/PhoXiInterface.h
+++ b/include/phoxi_camera/PhoXiInterface.h
@@ -39,6 +39,16 @@ namespace phoxi_camera {
         PhoXiInterface();
 
         /**
+        * Types of rows (chars representing starting sign of row) returned by avahi-browse call.
+        */
+        enum AvahiRowDataType : char {
+            available = '+',
+            disappeared = '-',
+            scannersInfo = '=',
+            other = ' '
+        };
+
+        /**
         * Return all PhoXi 3D Scanners ids connected on network with all informations about dcevice.
         *
         * \throw PhoXiControlNotRunning when PhoXi Control is not running
@@ -86,9 +96,10 @@ namespace phoxi_camera {
         * Return all available scanners on network from avahi-browse call output
         *
         * \param stdoutPipe - avahi-browse call output
+        * \param type - type of avahi-browse output row
         * \return vector of all available scanners on network
         */
-        std::vector<std::string> getAvailableScanersID(char type, const std::vector<std::string> &stdoutPipe);
+        std::vector<std::string> getAvailableScanersID(AvahiRowDataType type, const std::vector<std::string> &stdoutPipe);
 
         /**
         * Return content from avahi-browse output row between begin and end signs.

--- a/include/phoxi_camera/PhoXiInterface.h
+++ b/include/phoxi_camera/PhoXiInterface.h
@@ -88,7 +88,7 @@ namespace phoxi_camera {
         * \param stdoutPipe - avahi-browse call output
         * \return vector of all available scanners on network
         */
-        std::vector<std::string> getAvailableScanersID(const std::vector<std::string> &stdoutPipe);
+        std::vector<std::string> getAvailableScanersID(char type, const std::vector<std::string> &stdoutPipe);
 
         /**
         * Return content from avahi-browse output row between begin and end signs.

--- a/src/PhoXiInterface.cpp
+++ b/src/PhoXiInterface.cpp
@@ -365,11 +365,11 @@ namespace phoxi_camera {
         return false;
     }
 
-    std::vector<std::string> PhoXiInterface::getAvailableScanersID(const std::vector<std::string> &stdoutPipe) {
+    std::vector<std::string> PhoXiInterface::getAvailableScanersID(const char type, const std::vector<std::string> &stdoutPipe) {
         std::vector<std::string> scannersList;
         std::string scannerMark = "PhoXi3DScan-";
         std::string scriptMark = "_3d-camera._tcp";
-        const char *marker = "+";
+        const char *marker = &type;
 
         for (auto &row : stdoutPipe) {
             if (row.front() == *marker) {
@@ -396,51 +396,83 @@ namespace phoxi_camera {
     std::map<std::string, std::string> PhoXiInterface::getScannersIPs() {
         std::map<std::string, std::string> scannersIPs;
 
-        // stderr is redirected to the classic stdout
-        // TODO: error handling
-        const char *command = "(avahi-browse -r -t _3d-camera._tcp) 2>&1";
+        // stderr from avahi-browse is redirected (and handled later) to stdout
+        const char *command = "(timeout 0.5 avahi-browse -r -t _3d-camera._tcp) 2>&1";
         char buffer[256];
         std::string result;
         FILE *pipe = popen(command, "r");
 
-        std::vector<std::string> resultByRows;
+        std::vector<std::string> connectedScanners;
+        std::vector<std::string> disappearedScanners;
+        std::vector<std::string> stderrOutput;
+
         if (!pipe) {
+            pclose(pipe);
             throw AvahiFailed("Avahi-browse operation failed");
         }
 
         while (fgets(buffer, sizeof buffer, pipe) != nullptr) {
             if (ferror(pipe)) {
                 pclose(pipe);
-                throw AvahiUnexpectedResults("Unexpected results from avahi-browse!");
+                throw AvahiUnexpectedResults("Unexpected results from avahi-browse command!");
             }
-            resultByRows.emplace_back(buffer);
-        }
 
+            // valid response row from avahi-bowse starts with these characters
+            char startingSign = buffer[0];
+            const char *marker1 = "+";
+            const char *marker2 = "=";
+            const char *marker3 = " ";
+            const char *marker4 = "-";
+
+            if ((startingSign == *marker1) || (startingSign == *marker2) || (startingSign == *marker3)) {
+                connectedScanners.emplace_back(buffer);
+            } else if (startingSign == *marker4) {
+                disappearedScanners.emplace_back(buffer);
+            } else {
+                stderrOutput.emplace_back(buffer);
+            }
+        }
         pclose(pipe);
 
-        std::vector<std::string> scannersList = getAvailableScanersID(resultByRows);
+        if (connectedScanners.empty()) {
+            ROS_WARN("Avahi-browse does not see any scanners.");
+            return scannersIPs;
+        }
 
-        int numberRowsToDelete = countRowsWithStartingSign('+', resultByRows);
-        resultByRows.erase(resultByRows.begin(), resultByRows.begin() + numberRowsToDelete);
+        std::vector<std::string> scannersList = getAvailableScanersID('+', connectedScanners);
+        std::vector<std::string> disappearedScannersList = getAvailableScanersID('-', disappearedScanners);
 
-        for(std::string scannerID: scannersList){
-            if (!checkScannersPresence(scannersList, scannerID)) {
+        int numberRowsToDelete = countRowsWithStartingSign('+', connectedScanners);
+        connectedScanners.erase(connectedScanners.begin(), connectedScanners.begin() + numberRowsToDelete);
+
+        for (std::string scannerID: scannersList) {
+            if (!checkScannersPresence(scannersList, scannerID) ||
+                checkScannersPresence(disappearedScannersList, scannerID)) {
                 scannersIPs.insert(std::pair<std::string, std::string>(scannerID, "unknown"));
+                continue;
             }
 
-            int scannersInfoRowNum = -1;
-            int i = 0;
-            while (scannersInfoRowNum == -1) {
-                std::size_t scannersInfoPos = resultByRows.at(i).find(scannerID);
+            // find corresponding row for current scanner information
+            bool rowFound = false;
+            int scannersInfoRowNum = 0;
+
+            // we need first occurrence of scannerID to get right row number
+            for (int i = 0; (i <= connectedScanners.size() - 1) && !rowFound; i++) {
+                std::size_t scannersInfoPos = connectedScanners.at((unsigned long) i).find(scannerID);
                 if (scannersInfoPos != std::string::npos) {
                     scannersInfoRowNum = i;
+                    rowFound = true;
                 }
-                i++;
+            }
+
+            // scanners response not present in stdout
+            if (!rowFound) {
+                continue;
             }
 
             std::vector<std::string> scannersInfo;
             for (int j = scannersInfoRowNum + 1; j < scannersInfoRowNum + 5; j++) {
-                scannersInfo.emplace_back(getContentBetweenSign(resultByRows.at(j), "[", "]"));
+                scannersInfo.emplace_back(getContentBetweenSign(connectedScanners.at(j), "[", "]"));
             }
 
 //            Other scanners parameters can be obtained from:
@@ -453,7 +485,18 @@ namespace phoxi_camera {
             std::string scannersIP = scannersInfo.at(1);
             scannersIPs.insert(std::pair<std::string, std::string>(scannerID, scannersIP));
         }
+
+        // SILENT avahi-browse warnings/errors
+        // we are terminating avahi-browse after 500ms (all available scanners provides their info under 500ms)
+//        if (!stderrOutput.empty()) {
+//            for (auto &err : stderrOutput) {
+//                if (err.find("Got SIGTERM, quitting") != std::string::npos) {
+//                    ROS_WARN("Avahi-browse terminated due to IPv4 retrieving long processing time");
+//                } else {
+//                    std::cout << err << std::endl;
+//                }
+//            }
+//        }
         return scannersIPs;
     }
-
 }

--- a/src/PhoXiInterface.cpp
+++ b/src/PhoXiInterface.cpp
@@ -395,7 +395,10 @@ namespace phoxi_camera {
 
     std::map<std::string, std::string> PhoXiInterface::getScannersIPs() {
         std::map<std::string, std::string> scannersIPs;
-        const char *command = "avahi-browse -r -t _3d-camera._tcp";
+
+        // stderr is redirected to the classic stdout
+        // TODO: error handling
+        const char *command = "(avahi-browse -r -t _3d-camera._tcp) 2>&1";
         char buffer[256];
         std::string result;
         FILE *pipe = popen(command, "r");


### PR DESCRIPTION
- stderr from avahi redirected to stdout, 
- errors are being handled internally, 
- parsing changed due to new avahi-error output: error: vector::_M_range_check should not appear at all
@ondrejsova please can u test its reliability?