### PR TITLE
Remove ROS dependent LOG macros from the libPhoXiInterface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,10 +142,10 @@ target_link_libraries(
   ${catkin_LIBRARIES}
 )
 
-target_link_libraries(
-  ${PROJECT_NAME}
-  ${catkin_LIBRARIES}
-  ${PROJECT_NAME}_Ros_Interface
+target_link_libraries( ${PROJECT_NAME}
+    PRIVATE
+        ${catkin_LIBRARIES}
+        ${PROJECT_NAME}_Ros_Interface
 )
 
 install(TARGETS ${PROJECT_NAME}_Ros_Interface ${PROJECT_NAME}_PhoXi_Interface

--- a/include/phoxi_camera/PhoXiInterface.h
+++ b/include/phoxi_camera/PhoXiInterface.h
@@ -36,7 +36,7 @@ namespace phoxi_camera {
         /**
         * Default constructor.
         */
-        PhoXiInterface();
+        PhoXiInterface() = default;
 
         /**
         * Types of rows (chars representing starting sign of row) returned by avahi-browse call.

--- a/src/PhoXiInterface.cpp
+++ b/src/PhoXiInterface.cpp
@@ -6,12 +6,6 @@
 #include <phoxi_camera/PhoXiConversions.h>
 
 namespace phoxi_camera {
-
-    PhoXiInterface::PhoXiInterface() {
-
-    }
-
-
     std::vector<PhoXiDeviceInformation> PhoXiInterface::deviceList() {
         if (!phoXiFactory.isPhoXiControlRunning()) {
             scanner.Reset();
@@ -26,9 +20,7 @@ namespace phoxi_camera {
         try {
             scannersIPs = PhoXiInterface::getScannersIPs();
         }
-        catch (PhoXiInterfaceException& e){
-            ROS_WARN_STREAM("Can not get scanner ip: " << e.what());
-        }
+        catch (PhoXiInterfaceException& e){}
 
         for (auto &device : deviceInfo) {
             if (scannersIPs.empty() || (scannersIPs.find(device.hwIdentification) == scannersIPs.end())) {
@@ -424,7 +416,6 @@ namespace phoxi_camera {
         pclose(pipe);
 
         if (connectedScanners.empty()) {
-            ROS_WARN("Avahi-browse does not see any scanners.");
             return scannersIPs;
         }
 
@@ -480,7 +471,6 @@ namespace phoxi_camera {
 //        if (!stderrOutput.empty()) {
 //            for (auto &err : stderrOutput) {
 //                if (err.find("Got SIGTERM, quitting") != std::string::npos) {
-//                    ROS_WARN("Avahi-browse terminated due to IPv4 retrieving long processing time");
 //                } else {
 //                    std::cout << err << std::endl;
 //                }


### PR DESCRIPTION
This allows to find_package the library without the need to link ROS libraries and without getting link errors on including it in a project without the ROS support.