### PR TITLE
Publish Camera Intrinsic Parameters

### DIFF
--- a/.github/workflows/.ci_install_phoxi_sdk_bionic.sh
+++ b/.github/workflows/.ci_install_phoxi_sdk_bionic.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Update and install packages required to install dependencies
+apt-get update --qq
+apt install -y --no-install-recommends wget unzip
+
+# Install the Photoneo SDK
+cd /tmp
+wget https://photoneo.com/files/installer/PhoXi/1.2.14/PhotoneoPhoXiControlInstaller-1.2.14-Ubuntu18-STABLE.run.zip -q
+unzip PhotoneoPhoXiControlInstaller-1.2.14-Ubuntu18-STABLE.run.zip
+chmod +x PhotoneoPhoXiControlInstaller-1.2.14-Ubuntu18-STABLE.run
+./PhotoneoPhoXiControlInstaller-1.2.14-Ubuntu18-STABLE.run

--- a/.github/workflows/.ci_install_phoxi_sdk_xenial.sh
+++ b/.github/workflows/.ci_install_phoxi_sdk_xenial.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Update and install packages required to install dependencies
+apt-get update --qq
+apt install -y --no-install-recommends wget tar
+
+# Install the Photoneo SDK
+cd /tmp
+wget https://photoneo.com/files/installer/PhoXi/1.2.14/PhotoneoPhoXiControlInstaller-1.2.14-Ubuntu16-STABLE.tar -q
+tar -xf PhotoneoPhoXiControlInstaller-1.2.14-Ubuntu16-STABLE.tar
+chmod +x PhotoneoPhoXiControlInstaller-1.2.14-Ubuntu16-STABLE.run
+./PhotoneoPhoXiControlInstaller-1.2.14-Ubuntu16-STABLE.run
+
+

--- a/.github/workflows/bionic_build.yml
+++ b/.github/workflows/bionic_build.yml
@@ -1,0 +1,27 @@
+name: Bionic-Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  industrial_ci:
+    name: Melodic
+    runs-on: ubuntu-latest
+    env:
+      CI_NAME: Bionic-Build
+      OS_NAME: ubuntu
+      OS_CODE_NAME: bionic
+      ROS_DISTRO: melodic
+      ROS_REPO: main
+      BEFORE_BUILD_TARGET_WORKSPACE: './ci/.ci_install_phoxi_sdk_bionic.sh'
+      BEFORE_BUILD_TARGET_WORKSPACE_EMBED: 'export PHOXI_CONTROL_PATH=/opt/PhotoneoPhoXiControl-'
+      NOT_TEST_BUILD: 'true'  # Don't run the tests because they depend on being connected to a scanner
+    steps:
+      - uses: actions/checkout@v2
+      - uses: 'ros-industrial/industrial_ci@master'
+        env: ${{env}}

--- a/.github/workflows/noetic_build.yml
+++ b/.github/workflows/noetic_build.yml
@@ -1,0 +1,27 @@
+name: Focal-Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  industrial_ci:
+    name: Noetic
+    runs-on: ubuntu-latest
+    env:
+      CI_NAME: Focal-Build
+      OS_NAME: ubuntu
+      OS_CODE_NAME: focal
+      ROS_DISTRO: noetic
+      ROS_REPO: main
+      BEFORE_BUILD_TARGET_WORKSPACE: './ci/.ci_install_phoxi_sdk_bionic.sh'
+      BEFORE_BUILD_TARGET_WORKSPACE_EMBED: 'export PHOXI_CONTROL_PATH=/opt/PhotoneoPhoXiControl-'
+      NOT_TEST_BUILD: 'true'  # Don't run the tests because they depend on being connected to a scanner
+    steps:
+      - uses: actions/checkout@v2
+      - uses: 'ros-industrial/industrial_ci@master'
+        env: ${{env}}

--- a/.github/workflows/xenial_build.yml
+++ b/.github/workflows/xenial_build.yml
@@ -1,0 +1,27 @@
+name: Xenial-Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  industrial_ci:
+    name: Kinetic
+    runs-on: ubuntu-latest
+    env:
+      CI_NAME: Xenial-Build
+      OS_NAME: ubuntu
+      OS_CODE_NAME: xenial
+      ROS_DISTRO: kinetic
+      ROS_REPO: main
+      BEFORE_BUILD_TARGET_WORKSPACE: './ci/.ci_install_phoxi_sdk_xenial.sh'
+      BEFORE_BUILD_TARGET_WORKSPACE_EMBED: 'export PHOXI_CONTROL_PATH=/opt/PhotoneoPhoXiControl-1.2.14'
+      NOT_TEST_BUILD: 'true'  # Don't run the tests because they depend on being connected to a scanner
+    steps:
+      - uses: actions/checkout@v2
+      - uses: 'ros-industrial/industrial_ci@master'
+        env: ${{env}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(phoxi_camera)
 
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+
 find_package(PhoXi REQUIRED CONFIG PATHS "$ENV{PHOXI_CONTROL_PATH}")
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system)
@@ -90,7 +93,6 @@ catkin_package(
 )
 
 add_compile_options(-w)
-add_compile_options(-std=c++11)
 add_compile_options(-fpermissive)
 add_compile_options(-pthread)
 add_compile_options(-O2)

--- a/ci
+++ b/ci
@@ -1,0 +1,1 @@
+.github/workflows/

--- a/include/phoxi_camera/RosInterface.h
+++ b/include/phoxi_camera/RosInterface.h
@@ -27,6 +27,8 @@
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/image_encodings.h>
 #include <sensor_msgs/fill_image.h>
+#include <sensor_msgs/CameraInfo.h>
+#include <sensor_msgs/distortion_models.h>
 #include <std_srvs/Empty.h>
 #include <phoxi_camera/PhoXiInterface.h>
 #include <phoxi_camera/GetDeviceList.h>
@@ -166,6 +168,7 @@ namespace phoxi_camera {
         ros::Publisher rawTexturePub;
         ros::Publisher rgbTexturePub;
         ros::Publisher depthMapPub;
+        ros::Publisher cameraInfoPub;
 
         //dynamic reconfigure
         boost::recursive_mutex dynamicReconfigureMutex;

--- a/src/RosInterface.cpp
+++ b/src/RosInterface.cpp
@@ -46,6 +46,9 @@ namespace phoxi_camera {
         rawTexturePub = nh.advertise<sensor_msgs::Image>("texture", topic_queue_size, latch_topics);
         rgbTexturePub = nh.advertise<sensor_msgs::Image>("rgb_texture", topic_queue_size, latch_topics);
         depthMapPub = nh.advertise<sensor_msgs::Image>("depth_map", topic_queue_size, latch_topics);
+        cameraInfoPub = nh.advertise<sensor_msgs::CameraInfo>("camera_info",
+                                                              topic_queue_size,
+                                                              latch_topics);
 
         //set diagnostic Hw id
         diagnosticUpdater.setHardwareID("none");
@@ -342,6 +345,7 @@ namespace phoxi_camera {
         if (frame->Texture.Empty()) {
             ROS_WARN("Empty texture!");
         } else {
+            // Raw Texture
             sensor_msgs::Image texture;
             texture.header = header;
             texture.encoding = sensor_msgs::image_encodings::TYPE_32FC1;
@@ -351,6 +355,8 @@ namespace phoxi_camera {
                                    frame->Texture.Size.Width * sizeof(float), // stepSize
                                    frame->Texture.operator[](0));
             rawTexturePub.publish(texture);
+
+            // RGB Texture
             cv::Mat cvGreyTexture(frame->Texture.Size.Height, frame->Texture.Size.Width, CV_32FC1,
                                   frame->Texture.operator[](0));
             cv::normalize(cvGreyTexture, cvGreyTexture, 0, 255, CV_MINMAX);
@@ -360,6 +366,33 @@ namespace phoxi_camera {
             cv::cvtColor(cvGreyTexture, cvRgbTexture, CV_GRAY2RGB);
             cv_bridge::CvImage rgbTexture(header, sensor_msgs::image_encodings::RGB8, cvRgbTexture);
             rgbTexturePub.publish(rgbTexture.toImageMsg());
+
+            // Camera info
+            sensor_msgs::CameraInfo info;
+            info.header = header;
+            info.width = texture.width;
+            info.height = texture.height;
+            info.distortion_model = sensor_msgs::distortion_models::PLUMB_BOB;
+
+            // Camera matrix
+            for (std::size_t r = 0; r < 3; ++r)
+            {
+              for (std::size_t c = 0; c < 3; ++c)
+              {
+                info.K[c + r * 3] = scanner->CalibrationSettings->CameraMatrix.At(r, c);
+                info.P[c + r * 4] = scanner->CalibrationSettings->CameraMatrix.At(r, c);
+
+                // Set the R matrix to identity
+                if (r == c)
+                  info.R[c + r * 3] = 1.0;
+              }
+            }
+
+            // Distortion paramters
+            info.D = scanner->CalibrationSettings->DistortionCoefficients;
+
+            // Publish the camera info
+            cameraInfoPub.publish(info);
         }
         if (frame->ConfidenceMap.Empty()) {
             ROS_WARN("Empty confidence map!");


### PR DESCRIPTION
This PR adds a publisher for the intrinsic parameters of the sensor in the form of a `sensor_msgs/CameraInfo` message. The intrinsic parameters are important for rectifying the texture image that is published by the sensor for use in extrinsic calibration with libraries and calibration targets outside of the Photoneo domain. It also provides a convenient alternative to running [the provided script](https://wiki.photoneo.com/index.php/Frequently_asked_questions_and_Frequently_experienced_difficulties#How_do_I_retrieve_the_intrinsic_parameters_of_the_scanner.3F) to get intrinsic parameters

Addresses #37, builds on #52