### PR TITLE
Add publishing of pointcloud as topic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(phoxi_camera)
 
-find_package(PhoXi REQUIRED CONFIG PATHS "$ENV{PHOXI_CONTROL_PATH}")
+find_package(PhoXi REQUIRED CONFIG PATHS "$ENV{PHOXI_CONTROL_PATH}" "/opt/Photoneo/PhoXiControl-1.7.2/" )
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system)
 find_package(PCL REQUIRED COMPONENTS common)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,10 @@ install(TARGETS ${PROJECT_NAME}_Ros_Interface ${PROJECT_NAME}_PhoXi_Interface
 install(DIRECTORY include/${PROJECT_NAME}/
         DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
+install(DIRECTORY config launch meshes urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
 if (CATKIN_ENABLE_TESTING)
     find_package(rostest REQUIRED)
     add_rostest(test/launch/phoxi_camera_ros_interfaces_exist.test)
@@ -172,3 +176,4 @@ if (CATKIN_ENABLE_TESTING)
             ${catkin_LIBRARIES}
             ${PROJECT_NAME}_Ros_Interface)
 endif()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(phoxi_camera)
 find_package(PhoXi REQUIRED CONFIG PATHS "$ENV{PHOXI_CONTROL_PATH}")
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system)
+find_package(PCL REQUIRED COMPONENTS common)
 
 find_package(catkin REQUIRED
   COMPONENTS
@@ -87,10 +88,11 @@ catkin_package(
     eigen_conversions
   DEPENDS
     PhoXi
+    PCL
 )
 
 add_compile_options(-w)
-add_compile_options(-std=c++11)
+add_compile_options(-std=c++14)
 add_compile_options(-fpermissive)
 add_compile_options(-pthread)
 add_compile_options(-O2)

--- a/include/phoxi_camera/RosInterface.h
+++ b/include/phoxi_camera/RosInterface.h
@@ -48,6 +48,7 @@
 //std
 #include <vector>
 #include <algorithm>
+#include <thread>
 
 //others
 #include <phoxi_camera/PhoXiException.h>
@@ -58,6 +59,7 @@ namespace phoxi_camera {
     class RosInterface : protected PhoXiInterface {
     public:
         RosInterface();
+        ~RosInterface();
 
     protected:
         void publishFrame(pho::api::PFrame frame);
@@ -177,6 +179,9 @@ namespace phoxi_camera {
         diagnostic_updater::FunctionDiagnosticTask PhoXi3DscannerDiagnosticTask;
         ros::Timer diagnosticTimer;
 
+        std::thread continuous_aquisition_thread;
+        bool continuous_aquisition_thread_active;
+        void runContinuousAcquisition();
     };
 }
 

--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,7 @@
   <build_depend>eigen_conversions</build_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>message_generation</build_depend>
+  <build_depend>phoxicontrol</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>

--- a/src/phoxi_camera_node.cpp
+++ b/src/phoxi_camera_node.cpp
@@ -33,8 +33,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 int main(int argc, char** argv) {
     ros::init(argc, argv, "phoxi_camera");
 
+    ros::AsyncSpinner spinner(0);
+    spinner.start();
     phoxi_camera::RosInterface interface;
+    ros::waitForShutdown();
 
-    ros::spin();
     return 0;
 }


### PR DESCRIPTION
As reported in several issues, the Freerun mode does not currently publish the pointclouds as topics. This PR has a simple implementation tested in a MotionCam3D.