### PR TITLE
Distinguish between scanner alpha and not alpha [BIPI-5869]

### DIFF
--- a/include/phoxi_camera/PhoXiConversions.h
+++ b/include/phoxi_camera/PhoXiConversions.h
@@ -26,6 +26,12 @@ void toPhoXiCameraDeviceInforamtion(const pho::api::PhoXiDeviceInformation& phoX
 
     phoXiCameraDeviceInformation.firmwareVersion = phoXiDeviceInformation.FirmwareVersion;
     phoXiCameraDeviceInformation.variant = phoXiDeviceInformation.Variant;
+
+    if (phoXiDeviceInformation.CheckFeature("Alpha")) {
+        phoXiCameraDeviceInformation.isAlpha = true;
+    } else {
+        phoXiCameraDeviceInformation.isAlpha = false;
+    }
 }
 
 void toPhoXiCameraDeviceInforamtion(const std::vector<pho::api::PhoXiDeviceInformation>& phoXiDeviceInformation,

--- a/include/phoxi_camera/PhoXiDeviceInformation.h
+++ b/include/phoxi_camera/PhoXiDeviceInformation.h
@@ -49,6 +49,7 @@ namespace phoxi_camera {
         PhoXiConnectionStatus status;
         std::string firmwareVersion;
         std::string variant;
+        bool isAlpha;
     };
 }
 

--- a/include/phoxi_camera/RosConversions.h
+++ b/include/phoxi_camera/RosConversions.h
@@ -18,6 +18,7 @@ void phoXiDeviceInforamtionToRosMsg(const phoxi_camera::PhoXiDeviceInformation& 
     deviceInformationMsg.status.status = phoXiDeviceInformation.status;
     deviceInformationMsg.firmwareVersion = phoXiDeviceInformation.firmwareVersion;
     deviceInformationMsg.variant = phoXiDeviceInformation.variant;
+    deviceInformationMsg.isAlpha = phoXiDeviceInformation.isAlpha;
 }
 
 void phoXiDeviceInforamtionToRosMsg(const std::vector<phoxi_camera::PhoXiDeviceInformation>& phoXiDeviceInformation,

--- a/msg/DeviceInformation.msg
+++ b/msg/DeviceInformation.msg
@@ -5,3 +5,4 @@ string IPaddress
 phoxi_camera/DeviceConnectionStatus status
 string firmwareVersion
 string variant
+bool isAlpha


### PR DESCRIPTION
[BIPI-5869](https://photoneo.atlassian.net/browse/BIPI-5869)
Adding `isAlpha` flag into `device_information_list`. 

```
controller@mikulas-Dell-G15-5520:~$ rosservice call /phoxi_camera/get_device_list "{}" 
len: 33
out: 
  - COLORCAM-L9
  - COLORCAM-S1
  - Configured-DVJ-067
  - Configured-JEG-136
  - LDV-143
  - TBR-184
  - empty-48b02d8899f4
  - ynx
  - 2019-03-007-LC3
  - 2019-04-041-LC3
  - 2019-10-016-LC3
  - 2020-12-032-LC3
  - 2020-12-036-LC3
  - 2020-12-043-LC3
  - CTR-015
  - CTR-037
  - CTR-059
  - CTR-064
  - DKV-162
  - TBR-110
  - InstalledExamples-basic-example
  - InstalledExamples-color-example
  - UserExamples-delayering-2
  - UserExamples-hydac
  - UserExamples-anypick
  - UserExamples-delayering-photoneo
  - UserExamples-delayering
  - UserExamples-delayering-beers
  - UserExamples-drums-only
  - UserExamples-delayering-miki
  - UserExamples-delayering-yaskawa
  - UserExamples-delayering-kofola
  - UserExamples-delayering-1
device_information_list: 
  - 
    name: "MotionCam-3D-COLORCAM-L9"
    type: 
      type: 2
    hwIdentification: "COLORCAM-L9"
    IPaddress: "unknown"
    status: 
      status: 1
    firmwareVersion: "1.10.0"
    variant: "L+"
    isAlpha: False
  - 

```

[BIPI-5869]: https://photoneo.atlassian.net/browse/BIPI-5869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ