### PR TITLE
Adding new flag for Color devices [BIPI-6128]

### DIFF
--- a/include/phoxi_camera/PhoXiConversions.h
+++ b/include/phoxi_camera/PhoXiConversions.h
@@ -28,10 +28,14 @@ void toPhoXiCameraDeviceInforamtion(const pho::api::PhoXiDeviceInformation& phoX
     phoXiCameraDeviceInformation.firmwareVersion = phoXiDeviceInformation.FirmwareVersion;
     phoXiCameraDeviceInformation.variant = phoXiDeviceInformation.Variant;
 
+    phoXiCameraDeviceInformation.isAlpha = false;
+    phoXiCameraDeviceInformation.isColor = false;
+
     if (phoXiDeviceInformation.CheckFeature("Alpha")) {
         phoXiCameraDeviceInformation.isAlpha = true;
-    } else {
-        phoXiCameraDeviceInformation.isAlpha = false;
+    }
+    if (phoXiDeviceInformation.CheckFeature("Color")) {
+        phoXiCameraDeviceInformation.isColor = true;
     }
 }
 

--- a/include/phoxi_camera/PhoXiDeviceInformation.h
+++ b/include/phoxi_camera/PhoXiDeviceInformation.h
@@ -50,6 +50,7 @@ namespace phoxi_camera {
         std::string firmwareVersion;
         std::string variant;
         bool isAlpha;
+        bool isColor;
     };
 }
 

--- a/include/phoxi_camera/RosConversions.h
+++ b/include/phoxi_camera/RosConversions.h
@@ -19,6 +19,7 @@ void phoXiDeviceInforamtionToRosMsg(const phoxi_camera::PhoXiDeviceInformation& 
     deviceInformationMsg.firmwareVersion = phoXiDeviceInformation.firmwareVersion;
     deviceInformationMsg.variant = phoXiDeviceInformation.variant;
     deviceInformationMsg.isAlpha = phoXiDeviceInformation.isAlpha;
+    deviceInformationMsg.isColor = phoXiDeviceInformation.isColor;
 }
 
 void phoXiDeviceInforamtionToRosMsg(const std::vector<phoxi_camera::PhoXiDeviceInformation>& phoXiDeviceInformation,

--- a/msg/DeviceInformation.msg
+++ b/msg/DeviceInformation.msg
@@ -6,3 +6,4 @@ phoxi_camera/DeviceConnectionStatus status
 string firmwareVersion
 string variant
 bool isAlpha
+bool isColor


### PR DESCRIPTION
In order to distinguish between color / non color devices, we need to add new flag to the device info. https://github.com/photoneo/bps-web/pull/960

Unfortunately we need to check the phoxi device information feature, similar to checking if device is `Alpha`.